### PR TITLE
KCC-0020 fungible token covenant specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ KCCs do not propose changes to Kaspa consensus or core-node behavior. Such chang
 
 | Number | Category | Title | Author | Status |
 |--------|----------|-------|--------|--------|
-| [KCC-0020](kcc-0020.md) | Covenant | Fungible Token Covenant Specification | Manyfest, Michael Sutton, IzioDev | Draft |
+| [KCC-0020](kcc-0020.md) | Covenant | Fungible Token Covenant Specification | Manyfest, Michael Sutton, Romain Billot | Draft |

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ KCCs do not propose changes to Kaspa consensus or core-node behavior. Such chang
 
 | Number | Category | Title | Author | Status |
 |--------|----------|-------|--------|--------|
-| [KCC-0020](kcc-0020.md) | Covenant | Fungible Token Covenant Specification | Manyfest, Michael Sutton, Romain Billot | Draft |
+| [KCC-0020](kcc-0020.md) | Covenant | Fungible Token Covenant Specification | Sivan Helfer, Michael Sutton, Romain Billot | Draft |

--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ KCCs do not propose changes to Kaspa consensus or core-node behavior. Such chang
 
 | Number | Category | Title | Author | Status |
 |--------|----------|-------|--------|--------|
+| [KCC-0020](kcc-0020.md) | Covenant | Fungible Token Covenant Specification | Manyfest, Michael Sutton, IzioDev | Draft |

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ KCCs do not propose changes to Kaspa consensus or core-node behavior. Such chang
 |--------|----------|-------|--------|--------|
 | [1](kcc-0001.md) | Standard, Concepts, Covenant | Covenant definition, concepts, bytes layout and ABI | Romain Billot, Michael Sutton, Ori Newman | Draft |
 | [2](kcc-0002.md) | Program ABI Standard, Application | Authority Schemes | Romain Billot, Michael Sutton | Draft |
-| [20](kcc-0020.md) | Covenant | Fungible Token Covenant Specification | Sivan Helfer, Michael Sutton, Romain Billot | Draft |
+| [20](kcc-0020.md) | Application, Covenant | Fungible Token Covenant Specification | Sivan Helfer, Michael Sutton, Romain Billot | Draft |

--- a/kcc-0020-borrowed-receive-authorization.md
+++ b/kcc-0020-borrowed-receive-authorization.md
@@ -39,39 +39,39 @@ scheme.
 
 | Scheme | Meaning of `borrow_guard` | `borrow_witness` | Successor `borrow_guard` |
 | --- | --- | --- | --- |
-| `disabled` | Unused | Borrowing is rejected | Not applicable |
-| `amount-threshold` | First eight bytes contain the threshold | Empty | Unchanged |
-| `schnorr-signature` | Dedicated 32-byte public key | 65-byte Schnorr transaction signature | Unchanged |
-| `hash-chain` | Current 32-byte hash | Its 32-byte preimage | Revealed preimage |
+| `disabled/v1` | Unused | Borrowing is rejected | Not applicable |
+| `amount-threshold/v1` | First eight bytes contain the threshold | Empty | Unchanged |
+| `schnorr-signature/v1` | Dedicated 32-byte public key | 65-byte Schnorr transaction signature | Unchanged |
+| `hash-chain/v1` | Current 32-byte hash | Its 32-byte preimage | Revealed preimage |
 
 Every borrowed receive preserves `borrow_scheme`. A normal owner-authorized
 transfer may replace both `borrow_scheme` and `borrow_guard`.
 
-### Disabled
+### `disabled/v1`
 
-The `disabled` scheme prevents the UTXO from being borrowed and does not use
+The `disabled/v1` scheme prevents the UTXO from being borrowed and does not use
 `borrow_guard`. Receiving tokens therefore requires a separate output.
 
-### Amount threshold
+### `amount-threshold/v1`
 
-The `amount-threshold` scheme permits borrowing without sender-specific
+The `amount-threshold/v1` scheme permits borrowing without sender-specific
 authorization. The first eight bytes of `borrow_guard` contain the threshold
 that the token increase must strictly exceed; the remaining bytes are unused.
 This makes dust-level token spam ineffective, although sufficiently large
 transfers can still change the outpoint. No borrow witness is required.
 
-### Schnorr signature
+### `schnorr-signature/v1`
 
-The `schnorr-signature` scheme stores a dedicated borrow public key in
+The `schnorr-signature/v1` scheme stores a dedicated borrow public key in
 `borrow_guard`. A sender with access to the corresponding borrow signing key may
 authorize repeated borrows. This supports controlled reuse by recurring trusted
 senders without granting permission to spend the recipient's tokens or reduce
 the UTXO's KAS value. Other senders cannot make the locally recorded outpoint
 stale through Borrowed Receive.
 
-### Hash chain
+### `hash-chain/v1`
 
-The `hash-chain` scheme uses `borrow_guard` as the current commitment to an
+The `hash-chain/v1` scheme uses `borrow_guard` as the current commitment to an
 OTP-like sequence of one-time borrow authorizations. A wallet can preallocate a
 finite number of authorizations in advance. Each borrowed receive consumes one
 authorization and advances `borrow_guard`, without requiring a new signature

--- a/kcc-0020-borrowed-receive-authorization.md
+++ b/kcc-0020-borrowed-receive-authorization.md
@@ -1,4 +1,4 @@
-# KCC20 Borrowed Receive Guide
+# KCC20 Borrowed Receive Authorization
 
 Borrowed Receive is defined in
 [KCC20 Section 5](kcc-0020.md#5-borrowed-receive).

--- a/kcc-0020-borrowed-receive-authorization.md
+++ b/kcc-0020-borrowed-receive-authorization.md
@@ -5,10 +5,12 @@ Borrowed Receive is defined in
 
 ## Motivation
 
-KIP-9 requires each new UTXO to include KAS for storage.
+[KIP-9](https://github.com/kaspanet/kips/blob/master/kip-0009.md) prices UTXO-set
+growth through storage mass, which rises for small-valued new outputs.
 
-For token transfers, this means the sender must fund every new recipient token
-UTXO, or the recipient must co-sign and provide the required KAS.
+For token transfers, this means the sender normally funds each new recipient
+token UTXO with enough KAS, or the recipient co-signs and supplies an existing
+UTXO.
 
 Borrowed Receive allows the sender to use an existing recipient KCC20 UTXO as
 the receive target. Instead of creating a new recipient token UTXO, the sender
@@ -96,6 +98,28 @@ requiring `Hash(x_(i-1)) == x_i`. The revealed value becomes the successor's
 `borrow_guard`, ready for the next borrow.
 
 The authorizations are revealed in reverse order and cannot be reused. The
-wallet may provide them to an authorized sender in advance, allowing up to `n`
-ordered borrows while the wallet remains offline. The chain is exhausted after
-`x_0` is revealed.
+wallet may release them one at a time while monitoring each borrow, or several
+in advance while accepting that its outpoint may change until they are consumed
+or revoked. The chain is exhausted after `x_0` is revealed.
+
+#### Wallet-control model
+
+The hash-chain scheme is designed to keep the recipient's wallet in control of
+when its UTXO may change. The wallet releases one authorization while monitoring
+the network, records the confirmed successor outpoint, and keeps the next
+authorization private until another change is expected. Without a released
+authorization, the UTXO cannot be borrowed, so the wallet may go offline knowing
+that its outpoint will remain stable.
+
+The authorization is normally shared with an intended sender, but is not
+strictly bound to that sender. Once a transaction reveals it in the mempool,
+another party may copy it into a different valid borrowed-receive transaction
+and attempt to have that transaction confirmed first. Because both transactions
+spend the same UTXO, only one can be accepted. The competing transaction must
+still increase the recipient's token amount and preserve its KAS value, limiting
+the incentive for this form of front-running.
+
+Before going offline, a wallet that has released an authorization which remains
+unused may revoke it through an owner-authorized transfer or consume it itself
+in a valid borrowed receive. Applications that instead require
+transaction-specific authorization may use the Schnorr-signature scheme.

--- a/kcc-0020-borrowed-receive.md
+++ b/kcc-0020-borrowed-receive.md
@@ -1,0 +1,101 @@
+# KCC20 Borrowed Receive Guide
+
+Borrowed Receive is defined in
+[KCC20 Section 5](kcc-0020.md#5-borrowed-receive).
+
+## Motivation
+
+KIP-9 requires each new UTXO to include KAS for storage.
+
+For token transfers, this means the sender must fund every new recipient token
+UTXO, or the recipient must co-sign and provide the required KAS.
+
+Borrowed Receive allows the sender to use an existing recipient KCC20 UTXO as
+the receive target. Instead of creating a new recipient token UTXO, the sender
+consumes the existing UTXO and recreates it in place with a larger token amount.
+The recipient's normal owner authorization is not used, the KAS value cannot
+decrease, and the owner and extended state remain unchanged.
+
+Because the existing UTXO is consumed, every borrowed receive changes its
+outpoint. Without restrictions, an attacker could repeatedly send tiny token
+amounts to churn that outpoint. A wallet, signing device, or service relying on
+its locally known UTXOs would then have to reconnect and rediscover the current
+UTXO before using it.
+
+The borrow scheme controls who may cause this limited state change, or under
+what conditions it is allowed. It cannot remove the need to learn the new
+outpoint after an actual borrow, but it can prevent arbitrary or low-value
+borrows from making locally stored UTXO information stale.
+
+## Borrow authorization
+
+Each KCC20 state contains a `borrow_scheme` and a 32-byte `borrow_guard`.
+`borrow_scheme` selects the authorization rule, while `borrow_guard` holds its
+parameter or evolving state.
+
+Some schemes require an authorization parameter when borrowing. This parameter
+is referred to as `borrow_witness` and its meaning depends on the selected
+scheme.
+
+| Scheme | Meaning of `borrow_guard` | `borrow_witness` | Successor `borrow_guard` |
+| --- | --- | --- | --- |
+| `disabled` | Unused | Borrowing is rejected | Not applicable |
+| `amount-threshold` | First eight bytes contain the threshold | Empty | Unchanged |
+| `schnorr-signature` | Dedicated 32-byte public key | 65-byte Schnorr transaction signature | Unchanged |
+| `hash-chain` | Current 32-byte hash | Its 32-byte preimage | Revealed preimage |
+
+Every borrowed receive preserves `borrow_scheme`. A normal owner-authorized
+transfer may replace both `borrow_scheme` and `borrow_guard`.
+
+### Disabled
+
+The `disabled` scheme prevents the UTXO from being borrowed and does not use
+`borrow_guard`. Receiving tokens therefore requires a separate output.
+
+### Amount threshold
+
+The `amount-threshold` scheme permits borrowing without sender-specific
+authorization. The first eight bytes of `borrow_guard` contain the threshold
+that the token increase must strictly exceed; the remaining bytes are unused.
+This makes dust-level token spam ineffective, although sufficiently large
+transfers can still change the outpoint. No borrow witness is required.
+
+### Schnorr signature
+
+The `schnorr-signature` scheme stores a dedicated borrow public key in
+`borrow_guard`. A sender with access to the corresponding borrow signing key may
+authorize repeated borrows. This supports controlled reuse by recurring trusted
+senders without granting permission to spend the recipient's tokens or reduce
+the UTXO's KAS value. Other senders cannot make the locally recorded outpoint
+stale through Borrowed Receive.
+
+### Hash chain
+
+The `hash-chain` scheme uses `borrow_guard` as the current commitment to an
+OTP-like sequence of one-time borrow authorizations. A wallet can preallocate a
+finite number of authorizations in advance. Each borrowed receive consumes one
+authorization and advances `borrow_guard`, without requiring a new signature
+from the recipient.
+
+The idea originates in Rivest and Shamir's [PayWord and MicroMint: Two Simple
+Micropayment Schemes](https://people.csail.mit.edu/rivest/pubs/RS96a.pdf).
+
+To prepare a chain for `n` borrows, the wallet chooses a random value `x_0` and
+computes:
+
+```text
+x_1 = Hash(x_0)
+x_2 = Hash(x_1)
+...
+x_n = Hash(x_(n-1))
+```
+
+The initial `borrow_guard` is `x_n`, which commits to the complete sequence. A
+borrow against guard `x_i` reveals `x_(i-1)` and proves the authorization by
+requiring `Hash(x_(i-1)) == x_i`. The revealed value becomes the successor's
+`borrow_guard`, ready for the next borrow.
+
+The authorizations are revealed in reverse order and cannot be reused. The
+wallet may provide them to an authorized sender in advance, allowing up to `n`
+ordered borrows while the wallet remains offline. The chain is exhausted after
+`x_0` is revealed.

--- a/kcc-0020.md
+++ b/kcc-0020.md
@@ -1,5 +1,5 @@
 ```
-KCC20 Fungible Token Covenant Specification
+Title: KCC20 Fungible Token Covenant Specification
 Type: Covenant Specification
 Status: Draft
 Authors: Manyfest, Michael Sutton <msutton@cs.huji.ac.il>, Romain Billot <romain@izio.fr>
@@ -7,33 +7,34 @@ Comments-URI: https://kas-smiths.org/t/fungible-token-covenant-specification-kcc
 Created: 2026-07-15
 ```
 
-# Fungible Token Covenant Specification
+# KCC20 Fungible Token Covenant Specification
 
-KCC20 specifies a KCC1 program for fungible token covenants. It standardizes the
-[covenant state](#1-state), [transfer interface](#2-transfer-interface),
-[borrowed receive rules](#5-borrowed-receive), and [program
-artifact](#3-program-artifact) used to identify and interact with fungible token
-covenants through a KCC1 Program ABI.
+KCC20 specifies a convention for fungible-token covenants. It standardizes the
+[token state](#1-state), [transfer interface](#2-transfer-interface),
+[borrowed-receive rules](#5-borrowed-receive), and [KCC20
+information](#3-program-artifact) exposed through each covenant's Program ABI.
 
-This specification builds on the covenant terminology, value types, entrypoint
-and invocation rules, and state and template conventions defined by
-[KCC1](#ref-1).
+[KCC1](#ref-1) provides the underlying covenant terminology, value types,
+entrypoint and invocation rules, and state and template conventions used by
+KCC20.
 
 ## 1. State
 
-A KCC20 covenant state describes a token amount, its owner, its extended-state
-digest, and its borrowing settings.
+A KCC20 covenant state describes a token amount, its owner, its borrowing
+settings, and its extended-state digest.
 
-The Program ABI must expose a KCC20State record containing the following fields
-in order:
+The Program ABI exposes its state as a `KCC20State` record with the following
+fields, in order:
 
 ```text
-owner_reference:      byte[32]
-owner_profile:        byte
-amount:               int
-extension_commitment: byte[32]
-borrow_profile:       byte
-borrow_data:          byte[32]
+KCC20State {
+    owner_reference:      byte[32]
+    owner_profile:        byte
+    amount:               int
+    borrow_scheme:        byte
+    borrow_guard:         byte[32]
+    extension_commitment: byte[32]
+}
 ```
 
 The state contains exactly one token owner, as defined by [KCC2](#ref-2).
@@ -42,14 +43,15 @@ The state contains exactly one token owner, as defined by [KCC2](#ref-2).
 - `owner_profile` selects the principal-reference profile used to interpret
   `owner_reference`.
 - `amount` is the token quantity held and must be non-negative.
+- `borrow_scheme` selects the rule for borrowing this state as defined in
+  [Section 5, Borrowed Receive](#5-borrowed-receive).
+- `borrow_guard` contains the scheme-specific 32-byte guard: an amount
+  threshold, a Schnorr public key, the current hash-chain value, or unused bytes
+  when borrowing is disabled.
 - `extension_commitment` is a 32-byte digest of the token-specific extended
   state. The extended state itself is not stored directly in the KCC20 state.
   See [Section 4, State Extendability](#4-state-extendability) and KCC1 Section
   10 [[1]](#ref-1).
-- `borrow_profile` selects the rule for borrowing this state as defined in
-  [Section 5, Borrowed Receive](#5-borrowed-receive).
-- `borrow_data` contains the threshold, public key, or hash used by the selected
-  borrow profile.
 
 ## 2. Transfer Interface
 
@@ -93,7 +95,7 @@ The first byte of `witness` selects the leader's path:
 The remaining bytes contain either owner-authentication data or
 borrow-authorization data, depending on the selected path. A normal transfer
 uses them to authenticate the leader's owner according to its owner profile. A
-borrowed receive uses them according to its borrow profile as defined in
+borrowed receive uses them according to its borrow scheme as defined in
 Section 5. Any other first byte is invalid.
 
 Each remaining input in the active KCC20 covenant family invokes
@@ -127,8 +129,8 @@ information and KCC20 token configuration.
 | ABI types and encoding; state locations; entrypoints; templates | KCC1 |
 | Owner declaration, location, and profile interpretation | KCC2 |
 | Transfer bounds | KCC20 |
-| Extended-state digest | KCC20, following KCC1 Section 10 |
-| Borrow profiles and borrowed receive rules | KCC20 |
+| Extended-state commitment | KCC20, following KCC1 Section 10 |
+| Borrow schemes and borrowed-receive rules | KCC20 |
 
 The default KCC20 configuration is logically:
 
@@ -145,15 +147,15 @@ owner profiles:
 max_token_inputs:  2
 max_token_outputs: 2
 
-borrow profiles:
+borrow schemes:
     0x00: disabled
-    0x01: threshold
-    0x02: signed
+    0x01: amount-threshold
+    0x02: schnorr-signature
     0x03: hash-chain
 ```
 
-A conforming KCC20 program must recognize the disabled profile and support all
-three enabled borrow profiles. A non-default configuration must state its other
+A conforming KCC20 program must recognize the disabled scheme and support all
+three enabled borrow schemes. A non-default configuration must state its other
 overrides in its program artifact.
 
 ## 4. State Extendability
@@ -164,8 +166,9 @@ extended state itself. The artifact must describe the extended state's type and
 encoding, and how its digest is calculated and verified, following KCC1 Section
 10 [[1]](#ref-1).
 
-The standard transfer treats extended state as opaque. Writers must preserve
-`extension_commitment` unchanged in successor states.
+The standard transfer treats extended state as opaque and preserves
+`extension_commitment` unchanged in successor states. A KCC20 covenant may
+expose a separate program-specific entrypoint that updates extended state.
 
 ## 5. Borrowed Receive
 
@@ -180,61 +183,58 @@ A borrowed receive is available only to the leader, so there can be at most one
 per KCC20 covenant family. The borrowed successor is `next_states[0]`, at
 KCC20 covenant-family output position zero.
 
-The borrow profiles are:
+The borrow schemes are:
 
-| Value | Profile | Meaning of `borrow_data` | Borrow witness |
+| Value | Scheme | Meaning of `borrow_guard` | Borrow witness |
 | --- | --- | --- | --- |
 | `0x00` | Disabled | Unused | Borrowing is rejected |
-| `0x01` | Threshold | The first eight bytes contain the threshold that the token increase must exceed | Empty |
-| `0x02` | Signed | A 32-byte Schnorr public key | A 65-byte transaction signature |
+| `0x01` | Amount threshold | The first eight bytes contain the threshold that the token increase must exceed | Empty |
+| `0x02` | Schnorr signature | A 32-byte Schnorr public key | A 65-byte transaction signature |
 | `0x03` | Hash chain | The current 32-byte hash | Its 32-byte preimage |
 
-For a borrowed receive, `borrow_witness = witness[1..]`. For the threshold
-profile, the first eight bytes of `borrow_data` are a non-negative KCC1 `int`
-payload; only those eight bytes are used. The selected profile sets the amount
-threshold and the expected next borrow data:
+For a borrowed receive, `borrow_witness = witness[1..]`. For the amount-threshold
+scheme, the first eight bytes of `borrow_guard` are a non-negative KCC1 `int`
+payload; only those eight bytes are used. The selected scheme sets the amount
+threshold and the expected next borrow guard. Let `leader_state` be the state of
+the active leader input:
 
 ```text
 amount_threshold = 0
-next_borrow_data = borrow_data
+next_borrow_guard = borrow_guard
 
-match borrow_profile:
-    disabled:
-        reject
+if borrow_scheme == disabled:
+    reject
+else if borrow_scheme == amount-threshold:
+    amount_threshold = threshold from borrow_guard
+else if borrow_scheme == schnorr-signature:
+    verify borrow_witness with the public key in borrow_guard
+else if borrow_scheme == hash-chain:
+    require(Hash(borrow_witness) == borrow_guard)
+    next_borrow_guard = borrow_witness
+else:
+    reject
 
-    threshold:
-        amount_threshold = threshold from borrow_data
-
-    signed:
-        verify borrow_witness with the public key in borrow_data
-
-    hash chain:
-        require(Hash(borrow_witness) == borrow_data)
-        next_borrow_data = borrow_witness
-
-    otherwise:
-        reject
-
-amount_difference = next_states[0].amount - amount
+amount_difference = next_states[0].amount - leader_state.amount
 require(amount_difference > amount_threshold)
-require(next_states[0].borrow_data == next_borrow_data)
+require(next_states[0].borrow_guard == next_borrow_guard)
 ```
 
-`Hash` is the KCC1 Hash Function. Starting `amount_threshold` at zero means that
-the signed and hash-chain profiles require a positive token increase. The
-threshold profile replaces zero with its configured threshold.
+`Hash` is the KCC1 Hash Function. Every borrowed receive must increase the
+borrowed state's token amount. For the Schnorr-signature and hash-chain schemes,
+any positive increase is sufficient. For the amount-threshold scheme, the
+increase must be strictly greater than the configured threshold.
 
 The borrowed successor must preserve `owner_reference`, `owner_profile`,
-`extension_commitment`, and `borrow_profile`. It must use the expected
-`next_borrow_data`. The actual covenant-family output corresponding to
+`borrow_scheme`, and `extension_commitment`. It must use the expected
+`next_borrow_guard`. The actual covenant-family output corresponding to
 `next_states[0]` must have at least the KAS value of the borrowed input.
 
 The leader must preserve the total token amount across the active KCC20
 covenant family. All other inputs in that family use `transfer_delegator` and
 authenticate their own owners.
 
-A normal owner-authorized transfer may choose new `borrow_profile` and
-`borrow_data` values for its output states.
+A normal owner-authorized transfer may choose new `borrow_scheme` and
+`borrow_guard` values for its output states.
 
 ## 6. References
 

--- a/kcc-0020.md
+++ b/kcc-0020.md
@@ -183,7 +183,8 @@ effectively borrowed for the transaction and recreated with a higher token
 amount without the recipient's authorization. Its ownership and extended state
 stay unchanged, and its KAS value cannot be reduced.
 
-For an explanation of the problem and borrow schemes, see the [KCC20 Borrowed Receive](kcc-0020-borrowed-receive.md).
+For an explanation of the problem and borrow schemes, see
+[KCC20 Borrowed Receive Authorization](kcc-0020-borrowed-receive-authorization.md).
 
 A borrowed receive is available only to the leader, so there can be at most one
 per KCC20 covenant family. The borrowed successor is `next_states[0]`, at

--- a/kcc-0020.md
+++ b/kcc-0020.md
@@ -1,149 +1,173 @@
 ```
-Title: KCC20 Fungible Token Covenant Specification
+KCC20 Fungible Token Covenant Specification
 Type: Covenant Specification
 Status: Draft
-Authors: Manyfest, Michael Sutton <msutton@cs.huji.ac.il>, IzioDev
+Authors: Manyfest, Michael Sutton <msutton@cs.huji.ac.il>, Romain Billot <romain@izio.fr>
 Comments-URI: https://kas-smiths.org/t/fungible-token-covenant-specification-kcc20/8/
 Created: 2026-07-15
 ```
 
-# KCC20 Fungible Token Specification
+# Fungible Token Covenant Specification
 
-KCC20 defines the covenant surface needed for fungible token covenants to be
-recognized, transferred, and composed with other covenants.
+KCC20 specifies a KCC1 program for fungible token covenants. It standardizes the
+[covenant state](#1-state), [transfer interface](#2-transfer-interface),
+[borrowed receive rules](#5-borrowed-receive), and [program
+artifact](#3-program-artifact) used to identify and interact with fungible token
+covenants through a KCC1 Program ABI.
 
+This specification builds on the covenant terminology, value types, entrypoint
+and invocation rules, and state and template conventions defined by
+[KCC1](#ref-1).
 
-The convention specifies an extendable token state, a transfer interface, and a
-descriptor artifact used to identify and interact with a token covenant.
+## 1. State
 
-## State
+A KCC20 covenant state describes a token amount, its owner, its extended-state
+digest, and its borrowing settings.
 
-Every KCC20 covenant state must begin with the following fields, in this order:
-
-```text
-owner_identifier: bytes32
-identifier_type:  byte
-amount:           integer
-extended_state_digest: bytes32
-```
-
-- `owner_identifier` identifies the owner of the token quantity.
-- `identifier_type` defines how `owner_identifier` is interpreted.
-- `amount` is the token quantity held by the state.
-- `extended_state_digest` commits to the token-specific extended state. See
-  [State Extendability](#state-extendability).
-
-The defined identifier types are:
+The Program ABI must expose a KCC20State record containing the following fields
+in order:
 
 ```text
-IDENTIFIER_PUBKEY      = 0x00
-IDENTIFIER_SCRIPT_HASH = 0x01
-IDENTIFIER_COVENANT_ID = 0x02
+owner_reference:      byte[32]
+owner_profile:        byte
+amount:               int
+extension_commitment: byte[32]
+borrow_profile:       byte
+borrow_data:          byte[32]
 ```
 
-## Transfer Interface
+The state contains exactly one token owner, as defined by [KCC2](#ref-2).
 
-A KCC20 covenant must expose the following two entrypoints:
+- `owner_reference` identifies or commits to the owner.
+- `owner_profile` selects the principal-reference profile used to interpret
+  `owner_reference`.
+- `amount` is the token quantity held and must be non-negative.
+- `extension_commitment` is a 32-byte digest of the token-specific extended
+  state. The extended state itself is not stored directly in the KCC20 state.
+  See [Section 4, State Extendability](#4-state-extendability) and KCC1 Section
+  10 [[1]](#ref-1).
+- `borrow_profile` selects the rule for borrowing this state as defined in
+  [Section 5, Borrowed Receive](#5-borrowed-receive).
+- `borrow_data` contains the threshold, public key, or hash used by the selected
+  borrow profile.
+
+## 2. Transfer Interface
+
+The default KCC20 configuration uses the following transfer entrypoints:
 
 ```text
 transfer(
-    State[] next_states,
-    sig[] signatures,
-    byte[] witnesses
+    KCC20State[] next_states,
+    byte[] witness
 )
 
-transfer_delegator()
-```
-
-`transfer` is invoked by the first KCC20 covenant input as the leader
-entrypoint. It validates the complete state transition, while the other inputs
-verify and delegate to it. Its input data consists of:
-
-- `next_states`: the states created by the transfer, ordered by covenant output
-  index;
-- `signatures`: authorization signatures corresponding to consumed states; and
-- `witnesses`: per-input authorization metadata required for consumed states.
-
-The transfer entrypoint derives the previous token states from the consumed
-inputs, validates authorization and amount preservation, and verifies the
-successor outputs.
-
-Extended state is opaque to the transfer: its digest must be preserved
-unchanged. When multiple inputs are consolidated into one successor state, they
-must have the same `extended_state_digest`.
-
-Each remaining KCC20 covenant input invokes `transfer_delegator` with no input
-data to join the transfer declared by the leader.
-
-## Descriptor
-
-Each KCC20 covenant must provide a descriptor with the information required to
-decode its state and construct a transfer:
-
-```text
-KCC20Descriptor {
-    prefix: bytes
-    suffix: bytes
-    extended_state_layout: ExtendedStateLayout | none
-    kcc20_extensions: ExtensionId[]
-}
-```
-
-- `prefix` and `suffix` are the covenant script bytes before and after its
-  mutable state. Together they identify the token covenant template: the
-  spending rules applied to a KCC20 state.
-- `extended_state_layout` describes the shape of the token-specific state
-  committed by `extended_state_digest`. For example:
-
-  ```text
-  ExtendedStateLayout {
-      color:     byte
-      is_minter: boolean
-  }
-  ```
-
-- `kcc20_extensions` lists the standardized KCC20 behavioral
-  extensions implemented by the covenant.
-The descriptor must be published so tooling can identify the covenant, decode
-its state, reconstruct its outputs, and determine which KCC20 extensions it
-supports.
-
-## State Extendability
-
-A token covenant may extend the base KCC20 state using `extended_state_digest`, a
-commitment to token-specific state. The descriptor’s `extended_state_layout`
-defines the canonical encoding of that state:
-
-```
-extended_state_digest = blake2b(
-    encode(extended_state)
+transfer_delegator(
+    byte[] witness
 )
 ```
 
-Token-specific transitions may update the extended state and store its new
-digest in the successor state. The KCC20 `transfer` entrypoint treats extended
-state as opaque and must preserve its digest unchanged.
+A non-default configuration may override:
 
-## KCC20 Extensions
+- transfer and delegator entrypoints;
+- supported owner profiles and selector mapping;
+- maximum token inputs and outputs.
 
-A KCC20 extension defines optional standardized behavior on top of the base
-state and transfer interface. It is separate from token-specific extended
-state.
+Its program artifact must identify the configured transfer entrypoint and, when
+used, its delegator entrypoint.
 
-Supported extensions must be declared by their versioned `ExtensionId` in the
-descriptor's `kcc20_extensions` field. The field may be omitted when the
-covenant implements no standardized KCC20 extensions.
+`transfer` is invoked by the leader, as defined in KCC1 Section 9.1
+[[1]](#ref-1).
+`next_states` contains the states created by the active KCC20 covenant family,
+ordered by covenant-family output position. Its length must equal the number of
+continuation outputs in that family, and each element must equal the state in
+the corresponding output. The leader must validate each continuation's program,
+state, and covenant binding according to KCC1.
 
-The currently specified extension is [KCC20 Borrowed Receive Extension
-v1](#kcc20-borrowed-receive-extension-v1).
-
-### KCC20 Borrowed Receive Extension v1
-
-Extension ID:
+The first byte of `witness` selects the leader's path:
 
 ```text
-kcc20_borrowed_receive_v1
+0x00: normal owner-authorized transfer
+0x01: borrowed receive
 ```
+
+The remaining bytes contain either owner-authentication data or
+borrow-authorization data, depending on the selected path. A normal transfer
+uses them to authenticate the leader's owner according to its owner profile. A
+borrowed receive uses them according to its borrow profile as defined in
+Section 5. Any other first byte is invalid.
+
+Each remaining input in the active KCC20 covenant family invokes
+`transfer_delegator`. Its complete `witness` contains its owner-authorization
+data and has no normal-or-borrowed prefix. A delegator validates only its local
+owner. The leader validates the complete transition, including amount
+preservation and all successor states.
+
+The transfer is bounded by `max_token_inputs` and `max_token_outputs`, which
+limit the number of KCC20 states consumed and created by the transfer.
+
+Extended state is opaque to the transfer: `extension_commitment` must be
+preserved unchanged. When multiple inputs are consolidated into one successor
+state, they must have the same `extension_commitment`.
+
+KCC2 identifies the owner principal but does not define its complete
+authorization check or witness format. The Program ABI must describe how each
+supported owner profile uses `witness`.
+
+## 3. Program Artifact
+
+Each KCC20 covenant must publish a program artifact exposing the information
+required to decode its [state](#1-state) and construct a
+[transfer](#2-transfer-interface).
+
+The program artifact represents a KCC1 Program ABI extended with KCC2 ownership
+information and KCC20 token configuration.
+
+| Information | Defined by |
+| --- | --- |
+| ABI types and encoding; state locations; entrypoints; templates | KCC1 |
+| Owner declaration, location, and profile interpretation | KCC2 |
+| Transfer bounds | KCC20 |
+| Extended-state digest | KCC20, following KCC1 Section 10 |
+| Borrow profiles and borrowed receive rules | KCC20 |
+
+The default KCC20 configuration is logically:
+
+```text
+transfer entrypoint:           transfer(KCC20State[],byte[])
+delegator entrypoint:          transfer_delegator(byte[])
+
+owner profiles:
+    0x00: p2pkh-schnorr/v1
+    0x01: p2pkh-ecdsa/v1
+    0x02: program-hash/v1
+    0x03: covenant-id/v1
+
+max_token_inputs:  2
+max_token_outputs: 2
+
+borrow profiles:
+    0x00: disabled
+    0x01: threshold
+    0x02: signed
+    0x03: hash-chain
+```
+
+A conforming KCC20 program must recognize the disabled profile and support all
+three enabled borrow profiles. A non-default configuration must state its other
+overrides in its program artifact.
+
+## 4. State Extendability
+
+A KCC20 covenant may extend its base state through `extension_commitment`. This
+field stores a digest of the token-specific extended state rather than the
+extended state itself. The artifact must describe the extended state's type and
+encoding, and how its digest is calculated and verified, following KCC1 Section
+10 [[1]](#ref-1).
+
+The standard transfer treats extended state as opaque. Writers must preserve
+`extension_commitment` unchanged in successor states.
+
+## 5. Borrowed Receive
 
 Receiving tokens normally means creating a new UTXO and funding it with KAS,
 even when the recipient already has a compatible token UTXO. Borrowed Receive
@@ -152,33 +176,69 @@ effectively borrowed for the transaction and recreated with a higher token
 amount without the recipient's authorization. Its ownership and extended state
 stay unchanged, and its KAS value cannot be reduced.
 
-A borrowed receive input is identified by the reserved witness value:
+A borrowed receive is available only to the leader, so there can be at most one
+per KCC20 covenant family. The borrowed successor is `next_states[0]`, at
+KCC20 covenant-family output position zero.
+
+The borrow profiles are:
+
+| Value | Profile | Meaning of `borrow_data` | Borrow witness |
+| --- | --- | --- | --- |
+| `0x00` | Disabled | Unused | Borrowing is rejected |
+| `0x01` | Threshold | The first eight bytes contain the threshold that the token increase must exceed | Empty |
+| `0x02` | Signed | A 32-byte Schnorr public key | A 65-byte transaction signature |
+| `0x03` | Hash chain | The current 32-byte hash | Its 32-byte preimage |
+
+For a borrowed receive, `borrow_witness = witness[1..]`. For the threshold
+profile, the first eight bytes of `borrow_data` are a non-negative KCC1 `int`
+payload; only those eight bytes are used. The selected profile sets the amount
+threshold and the expected next borrow data:
 
 ```text
-BORROWED_RECEIVE = 0xFF
+amount_threshold = 0
+next_borrow_data = borrow_data
+
+match borrow_profile:
+    disabled:
+        reject
+
+    threshold:
+        amount_threshold = threshold from borrow_data
+
+    signed:
+        verify borrow_witness with the public key in borrow_data
+
+    hash chain:
+        require(Hash(borrow_witness) == borrow_data)
+        next_borrow_data = borrow_witness
+
+    otherwise:
+        reject
+
+amount_difference = next_states[0].amount - amount
+require(amount_difference > amount_threshold)
+require(next_states[0].borrow_data == next_borrow_data)
 ```
 
-When `witnesses[i] == BORROWED_RECEIVE`, the consumed state at position `i` is
-paired with the successor state at the same position:
+`Hash` is the KCC1 Hash Function. Starting `amount_threshold` at zero means that
+the signed and hash-chain profiles require a positive token increase. The
+threshold profile replaces zero with its configured threshold.
 
-```text
-borrowed input i -> successor state i
-```
+The borrowed successor must preserve `owner_reference`, `owner_profile`,
+`extension_commitment`, and `borrow_profile`. It must use the expected
+`next_borrow_data`. The actual covenant-family output corresponding to
+`next_states[0]` must have at least the KAS value of the borrowed input.
 
-For that pair, `transfer` must enforce:
+The leader must preserve the total token amount across the active KCC20
+covenant family. All other inputs in that family use `transfer_delegator` and
+authenticate their own owners.
 
-- `next_states[i]` exists;
-- `owner_identifier` is unchanged;
-- `identifier_type` is unchanged;
-- `extended_state_digest` is unchanged;
-- `next_states[i].amount > prev_states[i].amount`; and
-- the successor output's KAS value is greater than or equal to the consumed
-  input's KAS value.
+A normal owner-authorized transfer may choose new `borrow_profile` and
+`borrow_data` values for its output states.
 
-The borrowed input is exempt only from its normal owner authorization.
-`signatures[i]` remains positionally present but is not verified for that input.
-The increase must be funded by other authorized token inputs, and the transfer must
-still preserve the total token amount.
+## 6. References
 
-Strict positional pairing keeps the recipient state one-to-one: borrowed inputs
-cannot be merged or target the same successor state.
+- <a id="ref-1"></a>[1] [KCC1, Covenant definition, concepts, bytes layout and
+  ABI](https://github.com/kaspanet/kccs/pull/3).
+- <a id="ref-2"></a>[2] [KCC2, Control Principal References in Program
+  ABIs](https://github.com/kaspanet/kccs/pull/5).

--- a/kcc-0020.md
+++ b/kcc-0020.md
@@ -1,9 +1,10 @@
 ```
-Title: KCC20 Fungible Token Covenant Specification
-Type: Covenant Specification
-Status: Draft
+KCC: 20
+Layer: Application
+Title: Fungible Token Covenant Specification
 Authors: Manyfest, Michael Sutton <msutton@cs.huji.ac.il>, Romain Billot <romain@izio.fr>
 Comments-URI: https://kas-smiths.org/t/fungible-token-covenant-specification-kcc20/8/
+Status: Draft
 Created: 2026-07-15
 ```
 
@@ -138,10 +139,11 @@ transfer entrypoint:           transfer(KCC20State[],byte[])
 delegator entrypoint:          transfer_delegator(byte[])
 
 owner schemes:
-    0x00: p2pkh-schnorr/v1
-    0x01: p2pkh-ecdsa/v1
-    0x02: program-hash/v1
-    0x03: covenant-id/v1
+    0x00: p2pk-schnorr/v1  | pubkey
+    0x01: p2pkh-schnorr/v1 | byte[32]: P2PKHHash(pubkey)
+    0x02: p2pkh-ecdsa/v1   | byte[32]: P2PKHHash(ecdsa_pubkey)
+    0x03: program-hash/v1  | byte[32]: Hash(R)
+    0x04: covenant-id/v1   | byte[32]: KIP-20 Covenant ID
 
 max_token_inputs:  3
 max_token_outputs: 3
@@ -181,6 +183,8 @@ effectively borrowed for the transaction and recreated with a higher token
 amount without the recipient's authorization. Its ownership and extended state
 stay unchanged, and its KAS value cannot be reduced.
 
+For an explanation of the problem and borrow schemes, see the [KCC20 Borrowed Receive](kcc-0020-borrowed-receive.md).
+
 A borrowed receive is available only to the leader, so there can be at most one
 per KCC20 covenant family. The borrowed successor is `next_states[0]`, at
 KCC20 covenant-family output position zero.
@@ -191,7 +195,7 @@ The borrow schemes are:
 | --- | --- | --- | --- |
 | `0x00` | Disabled | Unused | Borrowing is rejected |
 | `0x01` | Amount threshold | The first eight bytes contain the threshold that the token increase must exceed | Empty |
-| `0x02` | Schnorr signature | A 32-byte Schnorr public key | A 65-byte transaction signature |
+| `0x02` | Schnorr signature | A 32-byte Schnorr public key | A 65-byte Schnorr transaction signature |
 | `0x03` | Hash chain | The current 32-byte hash | Its 32-byte preimage |
 
 For a borrowed receive, `borrow_witness = witness[1..]`. For the amount-threshold

--- a/kcc-0020.md
+++ b/kcc-0020.md
@@ -2,7 +2,7 @@
 KCC: 20
 Layer: Application
 Title: Fungible Token Covenant Specification
-Authors: Manyfest, Michael Sutton <msutton@cs.huji.ac.il>, Romain Billot <romain@izio.fr>
+Authors: Sivan Helfer <sivan@manyfest.dev>, Michael Sutton <msutton@cs.huji.ac.il>, Romain Billot <romain@izio.fr>
 Comments-URI: https://kas-smiths.org/t/fungible-token-covenant-specification-kcc20/8/
 Status: Draft
 Created: 2026-07-15

--- a/kcc-0020.md
+++ b/kcc-0020.md
@@ -142,7 +142,7 @@ owner schemes:
     0x00: p2pk-schnorr/v1  | pubkey
     0x01: p2pkh-schnorr/v1 | byte[32]: P2PKHHash(pubkey)
     0x02: p2pkh-ecdsa/v1   | byte[32]: P2PKHHash(ecdsa_pubkey)
-    0x03: program-hash/v1  | byte[32]: Hash(R)
+    0x03: p2sh/v1          | byte[32]: Blake2b(R)
     0x04: covenant-id/v1   | byte[32]: KIP-20 Covenant ID
 
 max_token_inputs:  3
@@ -153,10 +153,10 @@ The KCC20 borrow-scheme selector mapping is fixed:
 
 ```text
 borrow schemes:
-    0x00: disabled
-    0x01: amount-threshold
-    0x02: schnorr-signature
-    0x03: hash-chain
+    0x00: disabled/v1
+    0x01: amount-threshold/v1
+    0x02: schnorr-signature/v1
+    0x03: hash-chain/v1
 ```
 
 A conforming KCC20 program must recognize the disabled scheme and support all
@@ -194,28 +194,28 @@ The borrow schemes are:
 
 | Value | Scheme | Meaning of `borrow_guard` | Borrow witness |
 | --- | --- | --- | --- |
-| `0x00` | Disabled | Unused | Borrowing is rejected |
-| `0x01` | Amount threshold | The first eight bytes contain the threshold that the token increase must exceed | Empty |
-| `0x02` | Schnorr signature | A 32-byte Schnorr public key | A 65-byte Schnorr transaction signature |
-| `0x03` | Hash chain | The current 32-byte hash | Its 32-byte preimage |
+| `0x00` | `disabled/v1` | Unused | Borrowing is rejected |
+| `0x01` | `amount-threshold/v1` | The first eight bytes contain the threshold that the token increase must exceed | Empty |
+| `0x02` | `schnorr-signature/v1` | A 32-byte Schnorr public key | A 65-byte Schnorr transaction signature |
+| `0x03` | `hash-chain/v1` | The current 32-byte hash | Its 32-byte preimage |
 
-For a borrowed receive, `borrow_witness = witness[1..]`. For the amount-threshold
-scheme, the first eight bytes of `borrow_guard` are a non-negative KCC1 `int`
-payload; only those eight bytes are used. The selected scheme sets the amount
-threshold and the expected next borrow guard. Let `leader_state` be the state of
-the active leader input:
+For a borrowed receive, `borrow_witness = witness[1..]`. For the
+`amount-threshold/v1` scheme, the first eight bytes of `borrow_guard` are a
+non-negative KCC1 `int` payload; only those eight bytes are used. The selected
+scheme sets the amount threshold and the expected next borrow guard. Let
+`leader_state` be the state of the active leader input:
 
 ```text
 amount_threshold = 0
 next_borrow_guard = borrow_guard
 
-if borrow_scheme == disabled:
+if borrow_scheme == disabled/v1:
     reject
-else if borrow_scheme == amount-threshold:
+else if borrow_scheme == amount-threshold/v1:
     amount_threshold = threshold from borrow_guard
-else if borrow_scheme == schnorr-signature:
+else if borrow_scheme == schnorr-signature/v1:
     verify borrow_witness with the public key in borrow_guard
-else if borrow_scheme == hash-chain:
+else if borrow_scheme == hash-chain/v1:
     require(Hash(borrow_witness) == borrow_guard)
     next_borrow_guard = borrow_witness
 else:
@@ -227,9 +227,10 @@ require(next_states[0].borrow_guard == next_borrow_guard)
 ```
 
 `Hash` is the KCC1 Hash Function. Every borrowed receive must increase the
-borrowed state's token amount. For the Schnorr-signature and hash-chain schemes,
-any positive increase is sufficient. For the amount-threshold scheme, the
-increase must be strictly greater than the configured threshold.
+borrowed state's token amount. For the `schnorr-signature/v1` and
+`hash-chain/v1` schemes, any positive increase is sufficient. For the
+`amount-threshold/v1` scheme, the increase must be strictly greater than the
+configured threshold.
 
 The borrowed successor must preserve `owner`, `owner_scheme`, `borrow_scheme`,
 and `extension_commitment`. It must use the expected

--- a/kcc-0020.md
+++ b/kcc-0020.md
@@ -1,0 +1,184 @@
+```
+Title: KCC20 Fungible Token Covenant Specification
+Type: Covenant Specification
+Status: Draft
+Authors: Manyfest, Michael Sutton <msutton@cs.huji.ac.il>, IzioDev
+Comments-URI: https://kas-smiths.org/t/fungible-token-covenant-specification-kcc20/8/
+Created: 2026-07-15
+```
+
+# KCC20 Fungible Token Specification
+
+KCC20 defines the covenant surface needed for fungible token covenants to be
+recognized, transferred, and composed with other covenants.
+
+
+The convention specifies an extendable token state, a transfer interface, and a
+descriptor artifact used to identify and interact with a token covenant.
+
+## State
+
+Every KCC20 covenant state must begin with the following fields, in this order:
+
+```text
+owner_identifier: bytes32
+identifier_type:  byte
+amount:           integer
+extended_state_digest: bytes32
+```
+
+- `owner_identifier` identifies the owner of the token quantity.
+- `identifier_type` defines how `owner_identifier` is interpreted.
+- `amount` is the token quantity held by the state.
+- `extended_state_digest` commits to the token-specific extended state. See
+  [State Extendability](#state-extendability).
+
+The defined identifier types are:
+
+```text
+IDENTIFIER_PUBKEY      = 0x00
+IDENTIFIER_SCRIPT_HASH = 0x01
+IDENTIFIER_COVENANT_ID = 0x02
+```
+
+## Transfer Interface
+
+A KCC20 covenant must expose the following two entrypoints:
+
+```text
+transfer(
+    State[] next_states,
+    sig[] signatures,
+    byte[] witnesses
+)
+
+transfer_delegator()
+```
+
+`transfer` is invoked by the first KCC20 covenant input as the leader
+entrypoint. It validates the complete state transition, while the other inputs
+verify and delegate to it. Its input data consists of:
+
+- `next_states`: the states created by the transfer, ordered by covenant output
+  index;
+- `signatures`: authorization signatures corresponding to consumed states; and
+- `witnesses`: per-input authorization metadata required for consumed states.
+
+The transfer entrypoint derives the previous token states from the consumed
+inputs, validates authorization and amount preservation, and verifies the
+successor outputs.
+
+Extended state is opaque to the transfer: its digest must be preserved
+unchanged. When multiple inputs are consolidated into one successor state, they
+must have the same `extended_state_digest`.
+
+Each remaining KCC20 covenant input invokes `transfer_delegator` with no input
+data to join the transfer declared by the leader.
+
+## Descriptor
+
+Each KCC20 covenant must provide a descriptor with the information required to
+decode its state and construct a transfer:
+
+```text
+KCC20Descriptor {
+    prefix: bytes
+    suffix: bytes
+    extended_state_layout: ExtendedStateLayout | none
+    kcc20_extensions: ExtensionId[]
+}
+```
+
+- `prefix` and `suffix` are the covenant script bytes before and after its
+  mutable state. Together they identify the token covenant template: the
+  spending rules applied to a KCC20 state.
+- `extended_state_layout` describes the shape of the token-specific state
+  committed by `extended_state_digest`. For example:
+
+  ```text
+  ExtendedStateLayout {
+      color:     byte
+      is_minter: boolean
+  }
+  ```
+
+- `kcc20_extensions` lists the standardized KCC20 behavioral
+  extensions implemented by the covenant.
+The descriptor must be published so tooling can identify the covenant, decode
+its state, reconstruct its outputs, and determine which KCC20 extensions it
+supports.
+
+## State Extendability
+
+A token covenant may extend the base KCC20 state using `extended_state_digest`, a
+commitment to token-specific state. The descriptor’s `extended_state_layout`
+defines the canonical encoding of that state:
+
+```
+extended_state_digest = blake2b(
+    encode(extended_state)
+)
+```
+
+Token-specific transitions may update the extended state and store its new
+digest in the successor state. The KCC20 `transfer` entrypoint treats extended
+state as opaque and must preserve its digest unchanged.
+
+## KCC20 Extensions
+
+A KCC20 extension defines optional standardized behavior on top of the base
+state and transfer interface. It is separate from token-specific extended
+state.
+
+Supported extensions must be declared by their versioned `ExtensionId` in the
+descriptor's `kcc20_extensions` field. The field may be omitted when the
+covenant implements no standardized KCC20 extensions.
+
+The currently specified extension is [KCC20 Borrowed Receive Extension
+v1](#kcc20-borrowed-receive-extension-v1).
+
+### KCC20 Borrowed Receive Extension v1
+
+Extension ID:
+
+```text
+kcc20_borrowed_receive_v1
+```
+
+Receiving tokens normally means creating a new UTXO and funding it with KAS,
+even when the recipient already has a compatible token UTXO. Borrowed Receive
+lets the sender use that existing UTXO as the destination instead. It is
+effectively borrowed for the transaction and recreated with a higher token
+amount without the recipient's authorization. Its ownership and extended state
+stay unchanged, and its KAS value cannot be reduced.
+
+A borrowed receive input is identified by the reserved witness value:
+
+```text
+BORROWED_RECEIVE = 0xFF
+```
+
+When `witnesses[i] == BORROWED_RECEIVE`, the consumed state at position `i` is
+paired with the successor state at the same position:
+
+```text
+borrowed input i -> successor state i
+```
+
+For that pair, `transfer` must enforce:
+
+- `next_states[i]` exists;
+- `owner_identifier` is unchanged;
+- `identifier_type` is unchanged;
+- `extended_state_digest` is unchanged;
+- `next_states[i].amount > prev_states[i].amount`; and
+- the successor output's KAS value is greater than or equal to the consumed
+  input's KAS value.
+
+The borrowed input is exempt only from its normal owner authorization.
+`signatures[i]` remains positionally present but is not verified for that input.
+The increase must be funded by other authorized token inputs, and the transfer must
+still preserve the total token amount.
+
+Strict positional pairing keeps the recipient state one-to-one: borrowed inputs
+cannot be merged or target the same successor state.

--- a/kcc-0020.md
+++ b/kcc-0020.md
@@ -79,11 +79,18 @@ byte values, and maximum token input and output counts.
 
 `transfer` is invoked by the leader, as defined in KCC1 Section 9.1
 [[1]](#ref-1).
-`next_states` contains the states created by the active KCC20 covenant family,
+`next_states` contains the states created by the KCC20 covenant family,
 ordered by covenant-family output position. Its length must equal the number of
 continuation outputs in that family, and each element must equal the state in
 the corresponding output. The leader must validate each continuation's program,
 state, and covenant binding according to KCC1.
+
+> **Note:** A KCC20 "covenant family" is the transaction's inputs and
+> continuation outputs sharing the same KIP-20 `covenant_id`.
+
+The transfer entrypoint must validate that every `next_states[i].owner_scheme`
+is supported by the KCC20 token configuration. This prevents a transfer from
+creating an unspendable token state.
 
 The first byte of `witness` selects the leader's path:
 
@@ -98,7 +105,7 @@ uses them to authenticate the leader's owner according to its owner scheme. A
 borrowed receive uses them according to its borrow scheme as defined in
 Section 5. Any other first byte is invalid.
 
-Each remaining input in the active KCC20 covenant family invokes
+Each remaining input in the KCC20 covenant family invokes
 `transfer_delegator`. Its complete `witness` contains its owner-authorization
 data and has no normal-or-borrowed prefix. A delegator validates only its local
 owner. The leader validates the complete transition, including amount
@@ -237,7 +244,7 @@ and `extension_commitment`. It must use the expected
 `next_borrow_guard`. The actual covenant-family output corresponding to
 `next_states[0]` must have at least the KAS value of the borrowed input.
 
-The leader must preserve the total token amount across the active KCC20
+The leader must preserve the total token amount across the KCC20
 covenant family. All other inputs in that family use `transfer_delegator` and
 authenticate their own owners.
 

--- a/kcc-0020.md
+++ b/kcc-0020.md
@@ -1,18 +1,19 @@
 ```
 KCC: 20
-Layer: Application
+Category: Application, Covenant
 Title: Fungible Token Covenant Specification
 Authors: Sivan Helfer <sivan@manyfest.dev>, Michael Sutton <msutton@cs.huji.ac.il>, Romain Billot <romain@izio.fr>
 Comments-URI: https://kas-smiths.org/t/fungible-token-covenant-specification-kcc20/8/
 Status: Draft
 Created: 2026-07-15
+Updated: 2026-08-21
 ```
 
-# KCC20 Fungible Token Covenant Specification
+# Fungible Token Covenant Specification
 
 KCC20 specifies a convention for fungible-token covenants. It standardizes the
 [token state](#1-state), [transfer interface](#2-transfer-interface),
-[borrowed-receive rules](#5-borrowed-receive), and [KCC20
+[borrowed-receive rules](#5-borrowed-receive), and [program
 information](#3-program-artifact) exposed through each covenant's Program ABI.
 
 [KCC1](#ref-1) provides the underlying covenant terminology, value types,
@@ -70,12 +71,15 @@ transfer_delegator(
 A non-default configuration may override:
 
 - transfer and delegator entrypoints;
-- supported owner schemes and their assigned `owner_scheme` byte values;
+- the supported subset of KCC2 owner schemes; and
 - maximum token inputs and outputs.
 
 The program artifact must describe the configured transfer entrypoint, any
-delegator entrypoint, supported owner schemes and their assigned `owner_scheme`
-byte values, and maximum token input and output counts.
+delegator entrypoint, supported owner schemes using their canonical KCC2 byte
+values, and maximum token input and output counts.
+
+The transfer and delegator entrypoints must follow the KCC1 leader and
+delegator rules in Section 9.1 [[1]](#ref-1).
 
 `transfer` is invoked by the leader, as defined in KCC1 Section 9.1
 [[1]](#ref-1).
@@ -86,7 +90,7 @@ the corresponding output. The leader must validate each continuation's program,
 state, and covenant binding according to KCC1.
 
 > **Note:** A KCC20 "covenant family" is the transaction's inputs and
-> continuation outputs sharing the same KIP-20 `covenant_id`.
+> continuation outputs sharing the same KIP-20 `covenant_id` [[3]](#ref-3).
 
 The transfer entrypoint must validate that every `next_states[i].owner_scheme`
 is supported by the KCC20 token configuration. This prevents a transfer from
@@ -105,6 +109,16 @@ uses them to authenticate the leader's owner according to its owner scheme. A
 borrowed receive uses them according to its borrow scheme as defined in
 Section 5. Any other first byte is invalid.
 
+For the default configuration, the owner-authentication bytes are:
+
+| Owner scheme | Owner-authentication bytes |
+| --- | --- |
+| `p2pk-schnorr/v1` | 65-byte transaction signature |
+| `p2pkh-schnorr/v1` | 32-byte public key, then 65-byte transaction signature |
+| `p2pkh-ecdsa/v1` | 33-byte compressed public key, then 65-byte transaction signature |
+| `p2sh/v1` | One unsigned byte containing the authority input index |
+| `covenant-id/v1` | Empty |
+
 Each remaining input in the KCC20 covenant family invokes
 `transfer_delegator`. Its complete `witness` contains its owner-authorization
 data and has no normal-or-borrowed prefix. A delegator validates only its local
@@ -118,8 +132,8 @@ Extended state is opaque to the transfer: `extension_commitment` must be
 preserved unchanged. When multiple inputs are consolidated into one successor
 state, they must have the same `extension_commitment`.
 
-KCC2 identifies the owner principal but does not define its complete
-authorization check or witness format. The Program ABI must describe how each
+These layouts apply KCC2's minimum approval checks. A non-default configuration
+may override them, in which case the Program ABI must describe how each
 supported owner scheme uses `witness`.
 
 ## 3. Program Artifact
@@ -128,14 +142,14 @@ Each KCC20 covenant must publish a program artifact exposing the information
 required to decode its [state](#1-state) and construct a
 [transfer](#2-transfer-interface).
 
-The program artifact represents a KCC1 Program ABI extended with KCC2 ownership
-information and KCC20 token configuration.
+The program artifact represents a KCC1 Program ABI extended with KCC2 authority
+scheme information and KCC20 owner-role and token configuration.
 
 | Information | Defined by |
 | --- | --- |
 | ABI types and encoding; state locations; entrypoints; templates | KCC1 |
-| Owner declaration, location, and scheme interpretation | KCC2 |
-| Transfer bounds | KCC20 |
+| Authority scheme bytes and interpretation | KCC2 |
+| Owner role and field locations; transfer bounds | KCC20 |
 | Extended-state commitment | KCC20, following KCC1 Section 10 |
 | Borrow schemes and borrowed-receive rules | KCC20 |
 
@@ -195,7 +209,7 @@ For an explanation of the problem and borrow schemes, see
 
 A borrowed receive is available only to the leader, so there can be at most one
 per KCC20 covenant family. The borrowed successor is `next_states[0]`, at
-KCC20 covenant-family output position zero.
+covenant-family output position zero.
 
 The borrow schemes are:
 
@@ -254,6 +268,6 @@ A normal owner-authorized transfer may choose new `borrow_scheme` and
 ## 6. References
 
 - <a id="ref-1"></a>[1] [KCC1, Covenant definition, concepts, bytes layout and
-  ABI](https://github.com/kaspanet/kccs/pull/3).
-- <a id="ref-2"></a>[2] [KCC2, Control Principal References in Program
-  ABIs](https://github.com/kaspanet/kccs/pull/5).
+  ABI](kcc-0001.md).
+- <a id="ref-2"></a>[2] [KCC2, Authority Schemes](kcc-0002.md).
+- <a id="ref-3"></a>[3] [KIP-20, Covenant IDs](https://github.com/kaspanet/kips/blob/master/kip-0020.md).

--- a/kcc-0020.md
+++ b/kcc-0020.md
@@ -28,21 +28,19 @@ fields, in order:
 
 ```text
 KCC20State {
-    owner_reference:      byte[32]
-    owner_profile:        byte
     amount:               int
+    owner:                byte[32]
+    owner_scheme:         byte
     borrow_scheme:        byte
     borrow_guard:         byte[32]
     extension_commitment: byte[32]
 }
 ```
 
-The state contains exactly one token owner, as defined by [KCC2](#ref-2).
-
-- `owner_reference` identifies or commits to the owner.
-- `owner_profile` selects the principal-reference profile used to interpret
-  `owner_reference`.
 - `amount` is the token quantity held and must be non-negative.
+- `owner` identifies or commits to the token owner, as defined by
+  [KCC2](#ref-2).
+- `owner_scheme` selects the scheme used to interpret `owner`.
 - `borrow_scheme` selects the rule for borrowing this state as defined in
   [Section 5, Borrowed Receive](#5-borrowed-receive).
 - `borrow_guard` contains the scheme-specific 32-byte guard: an amount
@@ -71,12 +69,12 @@ transfer_delegator(
 A non-default configuration may override:
 
 - transfer and delegator entrypoints;
-- supported owner profiles and selector mapping;
+- supported owner schemes and their assigned `owner_scheme` byte values;
 - maximum token inputs and outputs.
 
 The program artifact must describe the configured transfer entrypoint, any
-delegator entrypoint, supported owner profiles and selector mapping, and maximum
-token input and output counts.
+delegator entrypoint, supported owner schemes and their assigned `owner_scheme`
+byte values, and maximum token input and output counts.
 
 `transfer` is invoked by the leader, as defined in KCC1 Section 9.1
 [[1]](#ref-1).
@@ -95,7 +93,7 @@ The first byte of `witness` selects the leader's path:
 
 The remaining bytes contain either owner-authentication data or
 borrow-authorization data, depending on the selected path. A normal transfer
-uses them to authenticate the leader's owner according to its owner profile. A
+uses them to authenticate the leader's owner according to its owner scheme. A
 borrowed receive uses them according to its borrow scheme as defined in
 Section 5. Any other first byte is invalid.
 
@@ -114,7 +112,7 @@ state, they must have the same `extension_commitment`.
 
 KCC2 identifies the owner principal but does not define its complete
 authorization check or witness format. The Program ABI must describe how each
-supported owner profile uses `witness`.
+supported owner scheme uses `witness`.
 
 ## 3. Program Artifact
 
@@ -128,7 +126,7 @@ information and KCC20 token configuration.
 | Information | Defined by |
 | --- | --- |
 | ABI types and encoding; state locations; entrypoints; templates | KCC1 |
-| Owner declaration, location, and profile interpretation | KCC2 |
+| Owner declaration, location, and scheme interpretation | KCC2 |
 | Transfer bounds | KCC20 |
 | Extended-state commitment | KCC20, following KCC1 Section 10 |
 | Borrow schemes and borrowed-receive rules | KCC20 |
@@ -139,7 +137,7 @@ The default KCC20 configuration is logically:
 transfer entrypoint:           transfer(KCC20State[],byte[])
 delegator entrypoint:          transfer_delegator(byte[])
 
-owner profiles:
+owner schemes:
     0x00: p2pkh-schnorr/v1
     0x01: p2pkh-ecdsa/v1
     0x02: program-hash/v1
@@ -228,8 +226,8 @@ borrowed state's token amount. For the Schnorr-signature and hash-chain schemes,
 any positive increase is sufficient. For the amount-threshold scheme, the
 increase must be strictly greater than the configured threshold.
 
-The borrowed successor must preserve `owner_reference`, `owner_profile`,
-`borrow_scheme`, and `extension_commitment`. It must use the expected
+The borrowed successor must preserve `owner`, `owner_scheme`, `borrow_scheme`,
+and `extension_commitment`. It must use the expected
 `next_borrow_guard`. The actual covenant-family output corresponding to
 `next_states[0]` must have at least the KAS value of the borrowed input.
 

--- a/kcc-0020.md
+++ b/kcc-0020.md
@@ -74,8 +74,9 @@ A non-default configuration may override:
 - supported owner profiles and selector mapping;
 - maximum token inputs and outputs.
 
-Its program artifact must identify the configured transfer entrypoint and, when
-used, its delegator entrypoint.
+The program artifact must describe the configured transfer entrypoint, any
+delegator entrypoint, supported owner profiles and selector mapping, and maximum
+token input and output counts.
 
 `transfer` is invoked by the leader, as defined in KCC1 Section 9.1
 [[1]](#ref-1).
@@ -144,9 +145,13 @@ owner profiles:
     0x02: program-hash/v1
     0x03: covenant-id/v1
 
-max_token_inputs:  2
-max_token_outputs: 2
+max_token_inputs:  3
+max_token_outputs: 3
+```
 
+The KCC20 borrow-scheme selector mapping is fixed:
+
+```text
 borrow schemes:
     0x00: disabled
     0x01: amount-threshold
@@ -155,8 +160,7 @@ borrow schemes:
 ```
 
 A conforming KCC20 program must recognize the disabled scheme and support all
-three enabled borrow schemes. A non-default configuration must state its other
-overrides in its program artifact.
+three enabled borrow schemes.
 
 ## 4. State Extendability
 


### PR DESCRIPTION
This PR adds a draft specification for fungible token covenants.
The proposal is the result of many conversations and iterations, with particular thanks to Michael Sutton and IzioDev for their contributions and feedback.

It continues the proposal raised in the Kas-Smiths discussion:

https://kas-smiths.org/t/fungible-token-covenant-specification-kcc20/8