### PR TITLE
KCC-0402: Covenant Payment Channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ KCCs do not propose changes to Kaspa consensus or core-node behavior. Such chang
 
 | Number | Category | Title | Author | Status |
 |--------|----------|-------|--------|--------|
+| 0402 | Covenant convention | Covenant Payment Channels | Kali123411 | Draft |

--- a/kcc-0402.md
+++ b/kcc-0402.md
@@ -1,0 +1,199 @@
+# KCC-0402: Covenant Payment Channels
+
+- **Number:** 0402 *(proposed, pending maintainer assignment — see note)*
+- **Category:** Covenant convention
+- **Title:** Covenant Payment Channels
+- **Authors:** Kali123411
+- **Status:** Draft
+- **Requires:** KCC-0001 (Covenant definition, ABI, bytes layout)
+
+> **On the number:** 0402 is proposed, not claimed — maintainers assign final numbers. It mirrors the
+> existing homage-numbering convention (KCC-0020 ↔ ERC-20): this convention underlies pay-per-call
+> commerce, and HTTP **402 "Payment Required"** — and the `x402` pattern it generalizes — is the
+> recognizable number for exactly that. Happy to take whatever number the maintainers prefer.
+
+## Table of Contents
+
+- [1. Abstract](#1-abstract)
+- [2. Scope and Dependencies](#2-scope-and-dependencies)
+- [3. Conventions](#3-conventions)
+- [4. Core Concepts](#4-core-concepts)
+- [5. The Channel Covenant](#5-the-channel-covenant)
+- [6. Voucher Format](#6-voucher-format)
+- [7. Channel Lifecycle](#7-channel-lifecycle)
+- [8. Offer and Discovery](#8-offer-and-discovery)
+- [9. Conformance Vectors](#9-conformance-vectors)
+- [10. Security Considerations](#10-security-considerations)
+- [11. Reference Implementation](#11-reference-implementation)
+
+## 1. Abstract
+
+This KCC specifies a convention for **unidirectional covenant payment channels** on Kaspa L1. A payer
+locks KAS in a channel covenant and pays a payee per interaction with off-chain **vouchers** — BIP340
+signatures over a monotonic cumulative total. The payee settles on-chain at any time with the latest
+voucher; consensus enforces the split (the payee receives exactly the signed total, the payer reclaims
+the remainder). Two on-chain transactions (open + close) carry an unbounded number of off-chain
+payments, with no custodian, facilitator, or sequencer in the money path. The convention defines the
+covenant's constructor arguments and spend paths, the voucher message and signature format, the channel
+lifecycle, and a machine-checkable conformance vector set, so that independent wallets, agents,
+indexers, and services interoperate.
+
+## 2. Scope and Dependencies
+
+This convention **depends on KCC-0001** for the covenant model, the Value ABI, integer/scalar encodings,
+and the P2SH covenant envelope. Constructor arguments and covenant state defined here MUST be encoded per
+KCC-0001; where this document describes byte layouts it does so in KCC-0001 terms.
+
+This convention **does not** propose any change to Kaspa consensus or core-node behavior. It relies only
+on covenant execution enabled by the Toccata rules (mainnet-active). It is an application-level
+convention layered on the covenant primitive.
+
+Out of scope: bidirectional/duplex channels, channel networks/routing across multiple hops, and the
+application transport used to carry vouchers (Section 8 gives one HTTP binding as a non-normative
+example; other transports are permitted).
+
+## 3. Conventions
+
+- **Hash function:** SHA-256, per KCC-0001.
+- **Signatures:** BIP340 Schnorr over the secp256k1 curve; public keys are 32-byte x-only.
+- **Integers on the wire:** unsigned, little-endian, fixed width where stated; amounts are in **sompi**
+  (1 KAS = 100,000,000 sompi) as unsigned integers.
+- The key words MUST, SHOULD, and MAY are to be interpreted as in RFC 2119.
+
+## 4. Core Concepts
+
+- **Channel:** a covenant instance holding the payer's principal, identified by its **channel id** — the
+  covenant id of its genesis outpoint (per KCC-0001).
+- **Voucher:** a BIP340 signature by the payer authorizing the payee to claim up to a **cumulative
+  total** of sompi from the channel. Vouchers are off-chain, single-signature, and require no chain
+  interaction to produce or verify.
+- **Cumulative total:** the running sum the payer has authorized so far, monotonically non-decreasing;
+  one voucher per payment carries the new total.
+- **Close:** a transition spending the channel that pays the signed total to the payee and the remainder
+  to the payer.
+- **Refund:** a transition, valid only at/after expiry, returning all unclaimed value to the payer.
+
+## 5. The Channel Covenant
+
+The channel covenant is constructed with the ordered arguments:
+
+| # | Name | Type (KCC-0001) | Meaning |
+|---|------|-----------------|---------|
+| 0 | `payer_pubkey`  | pubkey (x-only, 32B) | authorizes vouchers; receives the remainder on close/refund |
+| 1 | `payee_pubkey`  | pubkey (x-only, 32B) | receives the signed total on close |
+| 2 | `expiry_daa`    | u64 | DAA score at/after which `refund` becomes valid |
+| 3 | `maxfee_sompi`  | u64 | maximum tx fee a `close`/`refund` transition may consume |
+
+The channel id (covenant id) is a deterministic function of these arguments and the canonical template,
+so any party independently recompiles the covenant and verifies the P2SH address bit-for-bit
+(template-hash hardening, per KCC-0001). Implementations MUST pin the canonical template hash.
+
+The covenant admits exactly two spend paths and no others:
+
+- **`close`** — presents a voucher `(total, sig)`. The transition is valid iff `sig` is a BIP340
+  signature by `payer_pubkey` over the voucher message for `total` (Section 6), and the transition
+  creates one output of `total` sompi to a P2PK of `payee_pubkey` and one output of
+  `value − total − fee` sompi to a P2PK of `payer_pubkey`, with `fee ≤ maxfee_sompi`. No other output
+  arrangement is spendable.
+- **`refund`** — valid only when the spending transaction's DAA score is `≥ expiry_daa`; returns the
+  full value to a P2PK of `payer_pubkey`.
+
+A conforming covenant MUST make `close` and `refund` mutually exclusive before expiry and MUST NOT
+expose any third spending path.
+
+## 6. Voucher Format
+
+The voucher **message** is:
+
+```
+message = channel_id (32 bytes) || cumulative_total_sompi (8 bytes, unsigned little-endian)
+digest  = SHA-256(message)
+```
+
+with `0 < cumulative_total_sompi < 2^63`. The **voucher** is `BIP340-Sign(payer_privkey, digest)`, a
+bare 64-byte signature. Verification is `BIP340-Verify(payer_pubkey, digest, voucher)`.
+
+Including `channel_id` in the message binds a voucher to exactly one channel: a voucher can never be
+replayed against another channel, even between the same payer/payee pair. Totals are cumulative and
+MUST be non-decreasing; a payee MUST reject any voucher whose total does not advance beyond the highest
+already accepted for that channel.
+
+## 7. Channel Lifecycle
+
+1. **Open.** The payer compiles the covenant with `(payer_pubkey, payee_pubkey, expiry, maxfee)` where
+   `expiry ≥ current_daa + min_expiry_daa_delta`, funds it on-chain within the agreed
+   `[min_channel_sompi, max_channel_sompi]` bounds, and registers the genesis outpoint with the payee.
+   The payee MUST independently verify against a node: the recompiled P2SH address matches, the outpoint
+   exists with a covenant id, and the value is in bounds. Nothing is taken on trust.
+2. **Pay.** Per interaction the payer signs a voucher for the new cumulative total and sends it. The
+   payee accepts iff, over in-memory channel state (no chain round-trip):
+   `cumulative_total − already_accepted ≥ price` (payment covers the interaction),
+   `cumulative_total ≤ value − maxfee_sompi − floor` (the close tx can realize it; `floor` is the dust
+   remainder), and the voucher BIP340-verifies against `payer_pubkey`. It then advances
+   `already_accepted` to `cumulative_total`.
+3. **Close.** The payee submits a `close` with the latest voucher whenever it chooses (typically as
+   claimable value crosses a threshold or expiry nears). The payer's remainder returns in the same tx.
+   The payee SHOULD close with sufficient DAA margin before `expiry_daa`.
+4. **Refund.** If the payee never closes, the payer reclaims the full value with `refund` at/after
+   `expiry_daa`.
+
+## 8. Offer and Discovery
+
+An application MAY advertise a channel using this offer object (fields are sompi integer strings unless
+noted):
+
+```json
+{
+  "scheme": "kaspa-channel",
+  "network": "mainnet",
+  "payee_pubkey": "<x-only hex>",
+  "price_sompi": "3000000",
+  "min_channel_sompi": "100000000",
+  "max_channel_sompi": "500000000",
+  "min_expiry_daa_delta": 864000,
+  "maxfee_sompi": "5000000",
+  "open": "<registration endpoint>"
+}
+```
+
+The transport that carries vouchers is out of scope. As a non-normative example, the k402 reference
+implementation uses an HTTP header `X-K402-Payment: kaspa-channel <channel_id> <cumulative_total_sompi>
+<voucher_hex>` and an HTTP 402 challenge listing the offer above.
+
+## 9. Conformance Vectors
+
+A conforming implementation MUST reproduce the voucher message/digest bytes and MUST accept the frozen
+signatures and reject the negative cases in the vector set. Example:
+
+```
+channel_id = abab…ab (32 bytes)
+total      = 5000000
+message    = ababababababababababababababababababababababababababababababababab404b4c0000000000
+digest     = SHA-256(message)
+```
+
+The full machine-checkable set (valid vectors with frozen signatures plus reject cases — tampered total,
+wrong channel id, wrong key) is published at `tests/vectors/channel_vouchers.json` in the reference
+implementation and SHOULD be adopted as the conformance suite for this KCC.
+
+## 10. Security Considerations
+
+- **Compromised payee key** can claim at most the exact total the payer already signed, and only to the
+  payee's own address; the covenant forces the remainder back to the payer. It cannot exceed signed value
+  or redirect funds.
+- **Payer default is impossible** once a voucher is signed: the principal is locked in the covenant and
+  the payee can close unilaterally.
+- **Replay** is prevented by binding the voucher to `channel_id` and by monotonic totals.
+- **Over-value** is prevented by the payee's ceiling check (`total ≤ value − maxfee − floor`).
+- **Expiry races:** `refund` is valid only at/after `expiry_daa`; payees MUST close with margin.
+- **Root of trust** is the covenant itself. Until the covenant template is audited, implementations
+  SHOULD cap `max_channel_sompi` conservatively (reference: 5 KAS). A full threat model and a covenant
+  audit checklist accompany the reference implementation (`CHANNEL-THREAT-MODEL.md`).
+
+## 11. Reference Implementation
+
+The `k402` package (`pip install k402`) implements both sides — payer (`ChannelPayer`) and payee
+(`ChannelManager`) — with pure-Python voucher crypto (no native dependency) as the normative reference
+for Section 6. The scheme is proven on Kaspa **mainnet** (channel open/close transactions with the exact
+split enforced by consensus). Spec prose: PROTOCOL.md §4; conformance vectors: `tests/vectors/`;
+threat model: `CHANNEL-THREAT-MODEL.md`. Repository: https://github.com/Kali123411/k402


### PR DESCRIPTION
This PR adds a draft specification for **covenant payment channels** on Kaspa L1.

It specifies:
- the channel covenant's constructor arguments and its two spend paths — `close` enforces the split (the signed cumulative total to the payee, the remainder to the payer), `refund` returns everything to the payer at/after expiry;
- the off-chain **voucher** format: a BIP340 signature over `SHA-256(channel_id || cumulative_total_sompi[8, LE])`, with monotonic cumulative totals, so a payer authorizes value per interaction with no chain round-trip;
- the channel lifecycle (open + node-side verification, per-call metering, close, refund);
- a non-normative HTTP offer/transport binding; and
- a machine-checkable **conformance vector** set for the voucher wire format (frozen signatures + reject cases).

**Requires KCC-0001.** It does not change consensus rules; it is an application-level convention layered on the covenant primitive.

The scheme has a reference implementation — payer and payee, with pure-Python voucher crypto (no native dependency) — in the `k402` package, and is **proven on Kaspa mainnet**: channel open/close transactions with the split enforced by consensus. Conformance vectors, a threat model, and a covenant audit checklist ship with the reference implementation (https://github.com/Kali123411/k402).

**On the number:** 0402 is proposed, not claimed — maintainers assign final numbers. It follows the homage-numbering already in use (KCC-0020 ↔ ERC-20): HTTP **402 "Payment Required"** — and the `x402` pattern this generalizes — is the recognizable number for pay-per-call commerce. Happy to take whatever number the maintainers prefer.
