### PR TITLE
KCC-0002: authority schemes for program ABIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ KCCs do not propose changes to Kaspa consensus or core-node behavior. Such chang
 | Number | Category | Title | Author | Status |
 |--------|----------|-------|--------|--------|
 | [1](kcc-0001.md) | Standard, Concepts, Covenant | Covenant definition, concepts, bytes layout and ABI | Romain Billot, Michael Sutton, Ori Newman | Draft |
+| [2](kcc-0002.md) | Program ABI Standard, Application | Authority Schemes | Romain Billot, Michael Sutton | Draft |

--- a/kcc-0002.md
+++ b/kcc-0002.md
@@ -2,7 +2,7 @@
 KCC: 2
 Category: Program ABI Standard, Application
 Title: Authority Schemes
-Authors: Romain Billot <romain@izio.fr>
+Authors: Romain Billot <romain@izio.fr>, Michael Sutton <msutton@cs.huji.ac.il>
 Status: Draft
 ```
 
@@ -28,13 +28,13 @@ scheme** defines the value's KCC1 type, meaning, and usual form of approval.
 The following byte identifiers are canonical wherever a Program ABI or a
 higher-level convention selects a KCC2 authority scheme:
 
-| Byte   | Scheme             | Compatible KCC1 value                                      | Authority                             |
-| ------ | ------------------ | ---------------------------------------------------------- | ------------------------------------- |
-| `0x00` | `p2pk-schnorr/v1`  | `pubkey`                                                   | The 32-byte Schnorr public key itself |
-| `0x01` | `p2pkh-schnorr/v1` | `byte[32]` containing `P2PKHHash(pubkey)`                  | A 32-byte Schnorr public key          |
-| `0x02` | `p2pkh-ecdsa/v1`   | `byte[32]` containing `P2PKHHash(ecdsa_pubkey)`            | A compressed 33-byte ECDSA public key |
-| `0x03` | `p2sh/v1`          | `byte[32]` containing the KCC1 P2SH commitment to `R`      | One exact P2SH redeem script          |
-| `0x04` | `covenant-id/v1`   | `byte[32]` containing a KIP-20 Covenant ID                 | One continuing covenant lineage       |
+| Byte   | Scheme             | Compatible KCC1 value                                 | Authority                             |
+| ------ | ------------------ | ----------------------------------------------------- | ------------------------------------- |
+| `0x00` | `p2pk-schnorr/v1`  | `pubkey`                                              | The 32-byte Schnorr public key itself |
+| `0x01` | `p2pkh-schnorr/v1` | `byte[32]` containing `P2PKHHash(pubkey)`             | A 32-byte Schnorr public key          |
+| `0x02` | `p2pkh-ecdsa/v1`   | `byte[32]` containing `P2PKHHash(ecdsa_pubkey)`       | A compressed 33-byte ECDSA public key |
+| `0x03` | `p2sh/v1`          | `byte[32]` containing the KCC1 P2SH commitment to `R` | One exact P2SH redeem script          |
+| `0x04` | `covenant-id/v1`   | `byte[32]` containing a KIP-20 Covenant ID            | One continuing covenant lineage       |
 
 The byte identifies the scheme, not the authority. A higher-level convention
 MAY support only a subset of these schemes, but MUST use the canonical byte for

--- a/kcc-0002.md
+++ b/kcc-0002.md
@@ -28,13 +28,13 @@ scheme** defines the value's KCC1 type, meaning, and usual form of approval.
 The following byte identifiers are canonical wherever a Program ABI or a
 higher-level convention selects a KCC2 authority scheme:
 
-| Byte   | Scheme             | Compatible KCC1 value                           | Authority                             |
-| ------ | ------------------ | ----------------------------------------------- | ------------------------------------- |
-| `0x00` | `p2pk-schnorr/v1`  | `pubkey`                                        | The 32-byte Schnorr public key itself |
-| `0x01` | `p2pkh-schnorr/v1` | `byte[32]` containing `P2PKHHash(pubkey)`       | A 32-byte Schnorr public key          |
-| `0x02` | `p2pkh-ecdsa/v1`   | `byte[32]` containing `P2PKHHash(ecdsa_pubkey)` | A compressed 33-byte ECDSA public key |
-| `0x03` | `p2sh/v1`          | `byte[32]` containing `Blake2b(R)`              | One exact P2SH redeem script          |
-| `0x04` | `covenant-id/v1`   | `byte[32]` containing a KIP-20 Covenant ID      | One continuing covenant lineage       |
+| Byte   | Scheme             | Compatible KCC1 value                                      | Authority                             |
+| ------ | ------------------ | ---------------------------------------------------------- | ------------------------------------- |
+| `0x00` | `p2pk-schnorr/v1`  | `pubkey`                                                   | The 32-byte Schnorr public key itself |
+| `0x01` | `p2pkh-schnorr/v1` | `byte[32]` containing `P2PKHHash(pubkey)`                  | A 32-byte Schnorr public key          |
+| `0x02` | `p2pkh-ecdsa/v1`   | `byte[32]` containing `P2PKHHash(ecdsa_pubkey)`            | A compressed 33-byte ECDSA public key |
+| `0x03` | `p2sh/v1`          | `byte[32]` containing the KCC1 P2SH commitment to `R`      | One exact P2SH redeem script          |
+| `0x04` | `covenant-id/v1`   | `byte[32]` containing a KIP-20 Covenant ID                 | One continuing covenant lineage       |
 
 The byte identifies the scheme, not the authority. A higher-level convention
 MAY support only a subset of these schemes, but MUST use the canonical byte for
@@ -45,13 +45,11 @@ different KCC1 encoding.
 
 ## 3. Public-key authorities
 
-The P2PKH schemes use BLAKE3 keyed mode with a 32-byte output. The key is the
-UTF-8 encoding of `PublicKeyHash`, padded on the right with zero bytes to 32
-bytes:
+The P2PKH schemes use the keyed `Hash(x, key)` form defined by KCC1 Section 3.1
+[[1]](#ref-1). Their domain-separation key is `UTF8("PublicKeyHash")`:
 
 ```text
-key = UTF8("PublicKeyHash") || 00^(32 - len(UTF8("PublicKeyHash")))
-P2PKHHash(pubkey) = BLAKE3(key = key, input = pubkey, output_length = 32)
+P2PKHHash(pubkey) = Hash(pubkey, UTF8("PublicKeyHash"))
 ```
 
 The same key is used for both P2PKH schemes. Their public-key preimages are
@@ -72,18 +70,14 @@ witness location, and any additional authorization conditions.
 
 ### 4.1 P2SH authority
 
-For `p2sh/v1`, the authority value is the KCC1 P2SH redeem-script
-commitment `Blake2b(R)`. Approval under this scheme MUST include a transaction
-input with script public key version `0` and the following script:
+For `p2sh/v1`, the authority value is the P2SH redeem-script commitment to `R`
+defined by KCC1 Section 7 [[1]](#ref-1). Approval under this scheme MUST include
+a transaction input whose script public key is the KCC1 version-0 P2SH envelope
+for that commitment.
 
-```text
-OP_BLAKE2B OP_DATA_32 authority_value OP_EQUAL
-```
-
-This is the version-0 P2SH script public key defined by KCC1 (see
-[P2SH reference](kcc-0002/reference-code.md#4-silverscript-p2sh)). Because
-the matching input's program `R` must be revealed and accept the transaction,
-it participates as an authority according to its own script logic.
+Because the matching input's program `R` must be revealed and accept the
+transaction, it participates as an authority according to its own script logic
+(see [P2SH reference](kcc-0002/reference-code.md#4-silverscript-p2sh)).
 
 A higher-level convention defines how the matching P2SH input is located. It
 MAY include the input index in its witness, in which case the application checks

--- a/kcc-0002.md
+++ b/kcc-0002.md
@@ -120,14 +120,6 @@ predicate associated with its reference.
 
 `Hash` and `R` have the meanings defined by KCC1. The profile version fixes the
 interpretation of the value without introducing a different KCC1 encoding.
-`P2PKHHash` is defined in Section 5.2.
-
-### 5.1 Direct public-key principal
-
-With `p2pk-schnorr/v1`, an observer compares the principal value directly with its
-known Schnorr public keys.
-
-### 5.2 P2PKH technique
 
 The P2PKH profiles use KCC1's keyed `Hash` with a dedicated domain-separation
 key:
@@ -140,31 +132,12 @@ The same key is used for both P2PKH profiles. Their public-key preimages are
 unambiguous because `p2pkh-schnorr/v1` requires exactly 32 bytes and
 `p2pkh-ecdsa/v1` requires exactly 33 bytes.
 
-With `p2pkh-schnorr/v1`, an observer compares the principal value with
-`P2PKHHash(pubkey)` for each known 32-byte Schnorr public key. With
-`p2pkh-ecdsa/v1`, it does the same for each known compressed 33-byte ECDSA
-public key.
+### 5.1 Direct public-key principal
 
-For illustration, after an invocation has placed a signature and public key on
-the stack, a Schnorr authorization branch can validate the P2PKH commitment and
-then the signature as follows:
+With `p2pk-schnorr/v1`, an observer compares the principal value directly with its
+known Schnorr public keys.
 
-```text
-# initial stack: <signature> <pubkey>
-OP_DUP
-OP_DATA_32 <Key32(UTF8("PublicKeyHash"))>
-OP_BLAKE3WITHKEY
-OP_DATA_32 <principal_reference>
-OP_EQUALVERIFY
-OP_CHECKSIG
-```
-
-`OP_BLAKE3WITHKEY` consumes the duplicated public key and the normalized
-32-byte `Key32`. The original public key remains for `OP_CHECKSIG`. The ECDSA
-profile uses the same commitment sequence and replaces `OP_CHECKSIG` with
-`OP_CHECKSIGECDSA`.
-
-### 5.3 Covenant principals
+### 5.2 Covenant principals
 
 `program-hash/v1` identifies an exact covenant program. It is a natural
 reference for a stateless covenant, but it does not identify a unique UTXO:
@@ -196,7 +169,6 @@ inspect the ABI again if a continuation changes programs.
 ## 7. Open Questions
 
 - allow principal-reference profile "custom" expansions, e.g.: `custom/qt-xmas-tree-v1` so that community-defined profile can still be defined until they eventually become KCC-standard
-- it's hard to define control principal declarations without going into the "authentication" area that seems to be a natural follow-up KCC document. this one allows: "observers know where to look for owner(s)", but not "observers knows which entrypoints require what authentication mechanism(s)"
 
 ## 8. References
 

--- a/kcc-0002.md
+++ b/kcc-0002.md
@@ -1,176 +1,131 @@
 ```
 KCC: 2
-Layer: Program ABI Standard, Application
-Title: Control Principal References in Program ABIs
+Category: Program ABI Standard, Application
+Title: Authority Schemes
 Authors: Romain Billot <romain@izio.fr>
 Status: Draft
 ```
 
 ## 1. Abstract
 
-This specification defines a representation-independent convention by which a
-KCC1 Program ABI can expose a covenant's application-declared control
-principals. For each control principal, the ABI locates a principal reference
-in the decoded KCC1 data model and assigns a profile that defines the
-reference's semantics. A profile may be fixed or selected by another value
-already present in the program.
+This specification defines canonical schemes for authorities represented in
+KCC1 Program ABIs. An authority is a public key, key commitment, program, or
+covenant lineage whose approval may be required for an application operation.
 
-KCC2 reuses KCC1 types and decoding rules and standardizes only the information
-needed to discover control-principal references.
+Each scheme has a canonical byte identifier and defines how its authority value
+is encoded and interpreted. Higher-level conventions, such as KCC20, define the
+roles that use authorities, where their values and scheme bytes are stored, and
+the complete authorization rules and witness formats.
 
-## 2. Core Concepts
+> **Reference implementations:** Non-normative Silverscript and Argent code is
+> provided in [KCC2 reference code](kcc-0002/reference-code.md).
 
-A **control principal** is a principal associated with an application-declared
-control role.
+## 2. Authority schemes
 
-Application languages may expose a control principal as an identity. KCC2 uses
-"principal" for the representation-independent ABI concept and does not define
-broader identity semantics.
+An **authority value** identifies or commits to an authority. An **authority
+scheme** defines the value's KCC1 type, meaning, and usual form of approval.
 
-A **principal reference** is the typed KCC1 value that identifies or commits
-to that principal.
+The following byte identifiers are canonical wherever a Program ABI or a
+higher-level convention selects a KCC2 authority scheme:
 
-A **principal-reference profile** defines how a principal reference is encoded
-and interpreted. A control principal declaration connects a program-local role
-name to a principal reference and its profile.
+| Byte   | Scheme             | Compatible KCC1 value                           | Authority                             |
+| ------ | ------------------ | ----------------------------------------------- | ------------------------------------- |
+| `0x00` | `p2pk-schnorr/v1`  | `pubkey`                                        | The 32-byte Schnorr public key itself |
+| `0x01` | `p2pkh-schnorr/v1` | `byte[32]` containing `P2PKHHash(pubkey)`       | A 32-byte Schnorr public key          |
+| `0x02` | `p2pkh-ecdsa/v1`   | `byte[32]` containing `P2PKHHash(ecdsa_pubkey)` | A compressed 33-byte ECDSA public key |
+| `0x03` | `p2sh/v1`          | `byte[32]` containing `Blake2b(R)`              | One exact P2SH redeem script          |
+| `0x04` | `covenant-id/v1`   | `byte[32]` containing a KIP-20 Covenant ID      | One continuing covenant lineage       |
 
-## 3. Control principal declarations
+The byte identifies the scheme, not the authority. A higher-level convention
+MAY support only a subset of these schemes, but MUST use the canonical byte for
+every scheme it supports. Unassigned byte values are reserved for future KCCs.
 
-A Program ABI may expose zero or more **control principal declarations**.
-Abstractly, each declaration conveys:
+The scheme version fixes the interpretation of the value without introducing a
+different KCC1 encoding.
 
-```text
-ControlPrincipalDeclaration = (name, principal_location, profile_binding)
-```
+## 3. Public-key authorities
 
-`name` is an exact, case-sensitive, application-specific label that uniquely
-identifies the control role within the Program ABI.
-
-A Program ABI with multiple control principal declarations SHOULD list first
-the declaration that observers should use by default.
-
-`principal_location` identifies the KCC1 value that contains the current
-principal reference. `profile_binding` says how that value is to be
-interpreted. Declaration order does not otherwise affect their semantics.
-
-For example, a program could convey the following two declarations:
+The P2PKH schemes use BLAKE3 keyed mode with a 32-byte output. The key is the
+UTF-8 encoding of `PublicKeyHash`, padded on the right with zero bytes to 32
+bytes:
 
 ```text
-name = example_role_a
-principal_location = state.principal_references[0]
-profile_binding = fixed(p2pk-schnorr/v1)
-
-name = example_role_b
-principal_location = state.alternate_principal_reference
-profile_binding = selected(state.alternate_principal_kind, {
-    byte 00 => p2pkh-schnorr/v1,
-    byte 01 => program-hash/v1,
-    byte 02 => covenant-id/v1
-})
+key = UTF8("PublicKeyHash") || 00^(32 - len(UTF8("PublicKeyHash")))
+P2PKHHash(pubkey) = BLAKE3(key = key, input = pubkey, output_length = 32)
 ```
 
-The tuple and spelling above are explanatory notation only and do not prescribe
-an ABI artifact syntax.
-
-### 3.1 Profile bindings
-
-A profile binding is either:
-
-```text
-fixed(profile_id)
-
-selected(selector_location, {
-    selector_value_0 => profile_id_0,
-    ...
-})
-```
-
-With a fixed binding, the declared profile is both supported and active. With
-a selected binding, the case profiles are the supported set and the case whose
-typed value equals the current selector value is active. Case values are values
-of the selector's KCC1 type and are distinct.
-
-A selected binding describes an existing runtime choice. It does not add a tag
-to the program or change state encoding. An unknown profile or an unmatched
-selector means that the control principal's principal-reference profile is
-unsupported; it does not mean that the control principal declaration is
-absent.
-
-## 4. Value locations
-
-`principal_location` and `selector_location` are value locations as defined in
-KCC1 Section 5.7 [[1]](#ref-1).
-
-Every profile named by `profile_binding` MUST be compatible with the KCC1 type
-at `principal_location`. An invalid location or incompatible type makes the
-declaration invalid for the inspected program and state, not absent.
-
-## 5. Initial principal-reference profiles
-
-A principal-reference profile does not define the complete authorization
-predicate associated with its reference.
-
-| Profile            | Compatible KCC1 value                           | Principal-reference semantics                |
-| ------------------ | ----------------------------------------------- | -------------------------------------------- |
-| `p2pk-schnorr/v1`  | `pubkey`                                        | The 32-byte Schnorr public key itself        |
-| `p2pkh-schnorr/v1` | `byte[32]` containing `P2PKHHash(pubkey)`       | Commitment to a 32-byte Schnorr public key   |
-| `p2pkh-ecdsa/v1`   | `byte[32]` containing `P2PKHHash(ecdsa_pubkey)` | Commitment to a compressed 33-byte ECDSA key |
-| `program-hash/v1`  | `byte[32]` containing `Hash(R)`                 | One exact covenant program                   |
-| `covenant-id/v1`   | `byte[32]` containing a KIP-20 Covenant ID      | One continuing covenant lineage              |
-
-`Hash` and `R` have the meanings defined by KCC1. The profile version fixes the
-interpretation of the value without introducing a different KCC1 encoding.
-
-The P2PKH profiles use KCC1's keyed `Hash` with a dedicated domain-separation
-key:
-
-```text
-P2PKHHash(pubkey) = Hash(pubkey, UTF8("PublicKeyHash"))
-```
-
-The same key is used for both P2PKH profiles. Their public-key preimages are
+The same key is used for both P2PKH schemes. Their public-key preimages are
 unambiguous because `p2pkh-schnorr/v1` requires exactly 32 bytes and
 `p2pkh-ecdsa/v1` requires exactly 33 bytes.
 
-### 5.1 Direct public-key principal
+Approval under `p2pk-schnorr/v1` MUST include a valid signature by the public
+key stored in the authority value.
 
-With `p2pk-schnorr/v1`, an observer compares the principal value directly with its
-known Schnorr public keys.
+Approval under either P2PKH scheme MUST reveal the corresponding public key,
+require its `P2PKHHash` to equal the authority value, and include a valid
+signature by that key.
 
-### 5.2 Covenant principals
+The higher-level convention defines the signed message, signature encoding,
+witness location, and any additional authorization conditions.
 
-`program-hash/v1` identifies an exact covenant program. It is a natural
-reference for a stateless covenant, but it does not identify a unique UTXO:
-several UTXOs can contain the same program.
+## 4. Script and covenant authorities
 
-`covenant-id/v1` identifies one continuing KIP-20 [[2]](#ref-2) lineage. The
-program and state within that lineage may evolve while the Covenant ID remains
-stable.
+### 4.1 P2SH authority
 
-Discovering current lineage members or following either reference to control
-principals declared by another covenant is an observer concern outside KCC2.
+For `p2sh/v1`, the authority value is the KCC1 P2SH redeem-script
+commitment `Blake2b(R)`. Approval under this scheme MUST include a transaction
+input with script public key version `0` and the following script:
 
-## 6. Control principal inspection
+```text
+OP_BLAKE2B OP_DATA_32 authority_value OP_EQUAL
+```
 
-Given a UTXO and its Program ABI, a consumer that recognizes control principals:
+This is the version-0 P2SH script public key defined by KCC1 (see
+[P2SH reference](kcc-0002/reference-code.md#4-silverscript-p2sh)). Because
+the matching input's program `R` must be revealed and accept the transaction,
+it participates as an authority according to its own script logic.
 
-1. enumerates its control principal declarations;
-2. decodes each referenced root using KCC1;
-3. resolves the selector, when present, and chooses the active profile, and;
-4. follows the principal path and reads the principal value;
+A higher-level convention defines how the matching P2SH input is located. It
+MAY include the input index in its witness, in which case the application checks
+that the indexed input's script public key matches the construction above.
 
-For each declaration, the resulting information is its name, supported
-profiles, active profile, principal value, and value location.
+### 4.2 Covenant-ID authority
 
-A state-backed principal or selector is read again after every transition. An
-immutable principal is fixed for the inspected program, although an observer must
-inspect the ABI again if a continuation changes programs.
+Approval under `covenant-id/v1` MUST include a transaction input belonging to
+the KIP-20 lineage identified by the authority value. That
+input likewise participates according to its own contract logic. The program
+and state within a lineage may evolve while its Covenant ID remains stable.
 
-## 7. Open Questions
+KIP-20 provides `OpCovInputCount(covenant_id)`, so an application can test for
+participation by requiring `OpCovInputCount(authority_value) > 0` without an
+input-index witness. The matching input may be the active input itself.
 
-- allow principal-reference profile "custom" expansions, e.g.: `custom/qt-xmas-tree-v1` so that community-defined profile can still be defined until they eventually become KCC-standard
+For `covenant-id/v1`, requiring a matching input is the minimum approval check.
+A higher-level convention MAY additionally authenticate the program template
+and inspect the state of one or more matching inputs. It may also enumerate
+outputs belonging to the same covenant ID, authenticate their program
+templates, and validate their states. These checks constrain how the authority
+covenant participates, rather than merely requiring its presence.
 
-## 8. References
+Using a Covenant ID authority to require and optionally inspect another
+covenant's participation is a common form of inter-covenant communication
+(ICC).
+
+## 5. Use by higher-level conventions
+
+KCC2 does not prescribe generic role declarations or value-location metadata.
+A convention using KCC2 defines:
+
+1. the authority role, such as `owner`, `issuer`, or `admin`;
+2. the field containing the authority value;
+3. the field containing the authority-scheme byte, or a fixed scheme;
+4. the supported scheme subset; and
+5. the complete authorization and witness rules.
+
+For example, KCC20 defines an `owner` authority using `state.owner` as its
+value and `state.owner_scheme` as its KCC2 scheme byte.
+
+## 6. References
 
 - <a id="ref-1"></a>[1] [KCC1, Covenant definition, concepts, bytes layout and ABI](https://github.com/kaspanet/kccs/pull/3).
 - <a id="ref-2"></a>[2] [KIP-20, Covenant IDs](https://github.com/kaspanet/kips/blob/master/kip-0020.md).

--- a/kcc-0002.md
+++ b/kcc-0002.md
@@ -70,10 +70,10 @@ witness location, and any additional authorization conditions.
 
 ### 4.1 P2SH authority
 
-For `p2sh/v1`, the authority value is the P2SH redeem-script commitment to `R`
-defined by KCC1 Section 7 [[1]](#ref-1). Approval under this scheme MUST include
-a transaction input whose script public key is the KCC1 version-0 P2SH envelope
-for that commitment.
+For `p2sh/v1`, `R` is the exact P2SH redeem script and the authority value is
+its commitment as defined by KCC1 Section 7 [[1]](#ref-1). Approval under this
+scheme MUST include a transaction input whose script public key is the KCC1
+version-0 P2SH envelope for that commitment.
 
 Because the matching input's program `R` must be revealed and accept the
 transaction, it participates as an authority according to its own script logic
@@ -86,9 +86,9 @@ that the indexed input's script public key matches the construction above.
 ### 4.2 Covenant-ID authority
 
 Approval under `covenant-id/v1` MUST include a transaction input belonging to
-the KIP-20 lineage identified by the authority value. That
-input likewise participates according to its own contract logic. The program
-and state within a lineage may evolve while its Covenant ID remains stable.
+the KIP-20 [[2]](#ref-2) lineage identified by the authority value. That input
+likewise participates according to its own program logic. The program and state
+within a lineage may evolve while its Covenant ID remains stable.
 
 KIP-20 provides `OpCovInputCount(covenant_id)`, so an application can test for
 participation by requiring `OpCovInputCount(authority_value) > 0` without an
@@ -121,5 +121,5 @@ value and `state.owner_scheme` as its KCC2 scheme byte.
 
 ## 6. References
 
-- <a id="ref-1"></a>[1] [KCC1, Covenant definition, concepts, bytes layout and ABI](https://github.com/kaspanet/kccs/pull/3).
+- <a id="ref-1"></a>[1] [KCC1, Covenant definition, concepts, bytes layout and ABI](kcc-0001.md).
 - <a id="ref-2"></a>[2] [KIP-20, Covenant IDs](https://github.com/kaspanet/kips/blob/master/kip-0020.md).

--- a/kcc-0002.md
+++ b/kcc-0002.md
@@ -23,7 +23,7 @@ the complete authorization rules and witness formats.
 ## 2. Authority schemes
 
 An **authority value** identifies or commits to an authority. An **authority
-scheme** defines the value's KCC1 type, meaning, and usual form of approval.
+scheme** defines the value's KCC1 type, meaning, and minimum approval check.
 
 The following byte identifiers are canonical wherever a Program ABI or a
 higher-level convention selects a KCC2 authority scheme:

--- a/kcc-0002.md
+++ b/kcc-0002.md
@@ -1,0 +1,204 @@
+```
+KCC: 2
+Layer: Program ABI Standard, Application
+Title: Control Principal References in Program ABIs
+Authors: Romain Billot <romain@izio.fr>
+Status: Draft
+```
+
+## 1. Abstract
+
+This specification defines a representation-independent convention by which a
+KCC1 Program ABI can expose a covenant's application-declared control
+principals. For each control principal, the ABI locates a principal reference
+in the decoded KCC1 data model and assigns a profile that defines the
+reference's semantics. A profile may be fixed or selected by another value
+already present in the program.
+
+KCC2 reuses KCC1 types and decoding rules and standardizes only the information
+needed to discover control-principal references.
+
+## 2. Core Concepts
+
+A **control principal** is a principal associated with an application-declared
+control role.
+
+Application languages may expose a control principal as an identity. KCC2 uses
+"principal" for the representation-independent ABI concept and does not define
+broader identity semantics.
+
+A **principal reference** is the typed KCC1 value that identifies or commits
+to that principal.
+
+A **principal-reference profile** defines how a principal reference is encoded
+and interpreted. A control principal declaration connects a program-local role
+name to a principal reference and its profile.
+
+## 3. Control principal declarations
+
+A Program ABI may expose zero or more **control principal declarations**.
+Abstractly, each declaration conveys:
+
+```text
+ControlPrincipalDeclaration = (name, principal_location, profile_binding)
+```
+
+`name` is an exact, case-sensitive, application-specific label that uniquely
+identifies the control role within the Program ABI.
+
+A Program ABI with multiple control principal declarations SHOULD list first
+the declaration that observers should use by default.
+
+`principal_location` identifies the KCC1 value that contains the current
+principal reference. `profile_binding` says how that value is to be
+interpreted. Declaration order does not otherwise affect their semantics.
+
+For example, a program could convey the following two declarations:
+
+```text
+name = example_role_a
+principal_location = state.principal_references[0]
+profile_binding = fixed(p2pk-schnorr/v1)
+
+name = example_role_b
+principal_location = state.alternate_principal_reference
+profile_binding = selected(state.alternate_principal_kind, {
+    byte 00 => p2pkh-schnorr/v1,
+    byte 01 => program-hash/v1,
+    byte 02 => covenant-id/v1
+})
+```
+
+The tuple and spelling above are explanatory notation only and do not prescribe
+an ABI artifact syntax.
+
+### 3.1 Profile bindings
+
+A profile binding is either:
+
+```text
+fixed(profile_id)
+
+selected(selector_location, {
+    selector_value_0 => profile_id_0,
+    ...
+})
+```
+
+With a fixed binding, the declared profile is both supported and active. With
+a selected binding, the case profiles are the supported set and the case whose
+typed value equals the current selector value is active. Case values are values
+of the selector's KCC1 type and are distinct.
+
+A selected binding describes an existing runtime choice. It does not add a tag
+to the program or change state encoding. An unknown profile or an unmatched
+selector means that the control principal's principal-reference profile is
+unsupported; it does not mean that the control principal declaration is
+absent.
+
+## 4. Value locations
+
+`principal_location` and `selector_location` are value locations as defined in
+KCC1 Section 5.7 [[1]](#ref-1).
+
+Every profile named by `profile_binding` MUST be compatible with the KCC1 type
+at `principal_location`. An invalid location or incompatible type makes the
+declaration invalid for the inspected program and state, not absent.
+
+## 5. Initial principal-reference profiles
+
+A principal-reference profile does not define the complete authorization
+predicate associated with its reference.
+
+| Profile            | Compatible KCC1 value                           | Principal-reference semantics                |
+| ------------------ | ----------------------------------------------- | -------------------------------------------- |
+| `p2pk-schnorr/v1`  | `pubkey`                                        | The 32-byte Schnorr public key itself        |
+| `p2pkh-schnorr/v1` | `byte[32]` containing `P2PKHHash(pubkey)`       | Commitment to a 32-byte Schnorr public key   |
+| `p2pkh-ecdsa/v1`   | `byte[32]` containing `P2PKHHash(ecdsa_pubkey)` | Commitment to a compressed 33-byte ECDSA key |
+| `program-hash/v1`  | `byte[32]` containing `Hash(R)`                 | One exact covenant program                   |
+| `covenant-id/v1`   | `byte[32]` containing a KIP-20 Covenant ID      | One continuing covenant lineage              |
+
+`Hash` and `R` have the meanings defined by KCC1. The profile version fixes the
+interpretation of the value without introducing a different KCC1 encoding.
+`P2PKHHash` is defined in Section 5.2.
+
+### 5.1 Direct public-key principal
+
+With `p2pk-schnorr/v1`, an observer compares the principal value directly with its
+known Schnorr public keys.
+
+### 5.2 P2PKH technique
+
+The P2PKH profiles use KCC1's keyed `Hash` with a dedicated domain-separation
+key:
+
+```text
+P2PKHHash(pubkey) = Hash(pubkey, UTF8("PublicKeyHash"))
+```
+
+The same key is used for both P2PKH profiles. Their public-key preimages are
+unambiguous because `p2pkh-schnorr/v1` requires exactly 32 bytes and
+`p2pkh-ecdsa/v1` requires exactly 33 bytes.
+
+With `p2pkh-schnorr/v1`, an observer compares the principal value with
+`P2PKHHash(pubkey)` for each known 32-byte Schnorr public key. With
+`p2pkh-ecdsa/v1`, it does the same for each known compressed 33-byte ECDSA
+public key.
+
+For illustration, after an invocation has placed a signature and public key on
+the stack, a Schnorr authorization branch can validate the P2PKH commitment and
+then the signature as follows:
+
+```text
+# initial stack: <signature> <pubkey>
+OP_DUP
+OP_DATA_32 <Key32(UTF8("PublicKeyHash"))>
+OP_BLAKE3WITHKEY
+OP_DATA_32 <principal_reference>
+OP_EQUALVERIFY
+OP_CHECKSIG
+```
+
+`OP_BLAKE3WITHKEY` consumes the duplicated public key and the normalized
+32-byte `Key32`. The original public key remains for `OP_CHECKSIG`. The ECDSA
+profile uses the same commitment sequence and replaces `OP_CHECKSIG` with
+`OP_CHECKSIGECDSA`.
+
+### 5.3 Covenant principals
+
+`program-hash/v1` identifies an exact covenant program. It is a natural
+reference for a stateless covenant, but it does not identify a unique UTXO:
+several UTXOs can contain the same program.
+
+`covenant-id/v1` identifies one continuing KIP-20 [[2]](#ref-2) lineage. The
+program and state within that lineage may evolve while the Covenant ID remains
+stable.
+
+Discovering current lineage members or following either reference to control
+principals declared by another covenant is an observer concern outside KCC2.
+
+## 6. Control principal inspection
+
+Given a UTXO and its Program ABI, a consumer that recognizes control principals:
+
+1. enumerates its control principal declarations;
+2. decodes each referenced root using KCC1;
+3. resolves the selector, when present, and chooses the active profile, and;
+4. follows the principal path and reads the principal value;
+
+For each declaration, the resulting information is its name, supported
+profiles, active profile, principal value, and value location.
+
+A state-backed principal or selector is read again after every transition. An
+immutable principal is fixed for the inspected program, although an observer must
+inspect the ABI again if a continuation changes programs.
+
+## 7. Open Questions
+
+- allow principal-reference profile "custom" expansions, e.g.: `custom/qt-xmas-tree-v1` so that community-defined profile can still be defined until they eventually become KCC-standard
+- it's hard to define control principal declarations without going into the "authentication" area that seems to be a natural follow-up KCC document. this one allows: "observers know where to look for owner(s)", but not "observers knows which entrypoints require what authentication mechanism(s)"
+
+## 8. References
+
+- <a id="ref-1"></a>[1] [KCC1, Covenant definition, concepts, bytes layout and ABI](https://github.com/kaspanet/kccs/pull/3).
+- <a id="ref-2"></a>[2] [KIP-20, Covenant IDs](https://github.com/kaspanet/kips/blob/master/kip-0020.md).

--- a/kcc-0002/reference-code.md
+++ b/kcc-0002/reference-code.md
@@ -1,0 +1,131 @@
+# KCC2 reference code
+
+This document illustrates KCC2 authority checks in current
+[Silverscript](https://github.com/kaspanet/silverscript) and
+[Argent](https://github.com/argent-lang/argent) syntax. It is non-normative;
+KCC2 Sections 2 through 5 define the required semantics.
+
+For signature schemes, the higher-level convention defines the signed message,
+signature encoding, and witness layout.
+
+## 1. Silverscript P2PK Schnorr
+
+The following code verifies `p2pk-schnorr/v1`:
+
+```js
+function requireP2PKSchnorr(pubkey authority, sig signature) {
+    require(checkSig(signature, authority));
+}
+```
+
+## 2. Silverscript P2PKH Schnorr
+
+The following code verifies `p2pkh-schnorr/v1`:
+
+```js
+function requireP2PKHSchnorr(
+    byte[32] authority,
+    pubkey publicKey,
+    sig signature
+) {
+    byte[32] publicKeyHash = blake3WithKey(
+        byte[](publicKey),
+        byte[32](
+            byte[]("PublicKeyHash") + byte[19](0x00000000000000000000000000000000000000)
+        )
+    );
+    require(publicKeyHash == authority);
+    require(checkSig(signature, publicKey));
+}
+```
+
+## 3. Silverscript P2PKH ECDSA
+
+The following code shows the intended verification of `p2pkh-ecdsa/v1`.
+`checkSigECDSA` corresponds to Kaspa Script's `OP_CHECKSIGECDSA`, but may not be
+supported by the Silverscript version in use:
+
+```js
+function requireP2PKHECDSA(
+    byte[32] authority,
+    byte[33] publicKey,
+    sig signature
+) {
+    byte[32] publicKeyHash = blake3WithKey(
+        byte[](publicKey),
+        byte[32](
+            byte[]("PublicKeyHash") + byte[19](0x00000000000000000000000000000000000000)
+        )
+    );
+    require(publicKeyHash == authority);
+
+    // May not be supported by the Silverscript version in use.
+    require(checkSigECDSA(signature, publicKey));
+}
+```
+
+## 4. Silverscript P2SH
+
+The following code verifies a P2SH authority using an input index supplied by
+the higher-level convention:
+
+```js
+function requireP2SH(byte[32] authority, int authorityInput) {
+    byte[] expected = byte[](new ScriptPubKeyP2SH(authority)); // => 0x0000 OP_BLAKE2B OP_DATA_32 authority OP_EQUAL
+    require(tx.inputs[authorityInput].scriptPubKey == expected);
+}
+```
+
+## 5. Covenant-ID authority
+
+The following Silverscript code performs the minimum `covenant-id/v1` approval
+check:
+
+```js
+function requireCovenantId(byte[32] authority) {
+    require(OpCovInputCount(authority) > 0);
+}
+```
+
+### Argent reference code
+
+Argent is a language and transpiler for multi-contract, multi-application
+protocols built on Silverscript. It compiles Argent programs to Silverscript.
+Cross-covenant introspection and state-transition validation are part of its
+core domain, making Argent a natural higher-level example of KCC2 authority
+schemes.
+
+Argent's `cov_id.co_spent()` is a shortcut for the same minimum covenant-ID
+approval check:
+
+```js
+require(cov_id(authority).co_spent());
+```
+
+When an application must validate how the authority covenant participates, an
+Argent `observes` clause can authenticate its program template and inspect its
+input and output state. For example:
+
+```js
+entry authorize()
+observes remote by self.authority_id {
+    inputs {
+        before: Authority,
+    }
+
+    outputs {
+        after: Authority,
+    }
+} {
+    AuthorityState before = remote.inputs.before.state;
+    require(before.enabled);
+
+    require remote.outputs become {
+        after <- Authority(before),
+    };
+}
+```
+
+Here the `observes` declaration requires the named authority input and output,
+authenticates their `Authority` templates, exposes the decoded input state, and
+validates the declared successor state.


### PR DESCRIPTION
This specification defines a representation-independent convention by which a
KCC1 Program ABI can expose a covenant's application-declared control
principals. For each control principal, the ABI locates a principal reference
in the decoded KCC1 data model and assigns a profile that defines the
reference's semantics. A profile may be fixed or selected by another value
already present in the program.

KCC2 reuses KCC1 types and decoding rules and standardizes only the information
needed to discover control-principal references.
