### PR TITLE
KCC-0009 through KCC-0015: Seven Token Standards

### DIFF
--- a/KCC-0009-governed-token.md
+++ b/KCC-0009-governed-token.md
@@ -63,6 +63,10 @@ proposals: [{
 - **Escrow**: buyer, seller, arbitrator — 2 of 3 to release
 - **Inheritance fund**: 3 of 5 heirs to access
 
+## Encoding
+
+For the technical encoding of transfer operations, state field ordering, witness semantics, and positional input/output pairing, see KCC-0020 (Fungible Token Covenant Specification by Manyfest, Michael Sutton, and IzioDev). This standard defines the interface; KCC-0020 defines the byte-level implementation.
+
 ## Rules
 
 1. Governor set and quorum are immutable after deployment.

--- a/KCC-0009-governed-token.md
+++ b/KCC-0009-governed-token.md
@@ -1,0 +1,72 @@
+# KCC-0009: Governed Token Standard
+
+| Field | Value |
+|-------|-------|
+| **KCC** | 0009 |
+| **Category** | Asset Standard |
+| **Title** | Governed Token — Multi-Party Approval for Transfers |
+| **Author** | Vida Wallet |
+| **Status** | Draft |
+| **Created** | 2026-07-25 |
+
+## Abstract
+
+A token requiring N-of-M authorized parties to approve every transfer. The governance lives in the token itself — not in a wallet wrapper. No single party can move funds. This does not exist as a standard on any blockchain.
+
+## Motivation
+
+Existing multisig wallets control entire accounts. A governed token controls the asset. Four differences:
+
+| | Multisig Wallet | Governed Token |
+|---|---|---|
+| Control scope | All assets in wallet | This token only |
+| Audit trail | Wallet transactions | Per-proposal on-chain |
+| Recovery | Key rotation | Governor set change (requires quorum) |
+| Composability | None — wallet-level | Covenant composable with commerce contracts |
+
+## Specification
+
+| # | Entrypoint | Caller | Description |
+|---|-----------|--------|-------------|
+| 1 | `propose` | Governor | Propose `amount` → `recipient` with `reason_hash` |
+| 2 | `second` | Governor | Second the proposal. Must differ from proposer. |
+| 3 | `veto` | Governor | Block proposal if veto power is configured |
+| 4 | `execute` | Any | Quorum reached, delay elapsed → transfer executes |
+| 5 | `cancel` | Proposer | Withdraw pending proposal |
+| 6 | `mint` | Owner | Create tokens |
+| 7 | `burn` | Owner | Destroy tokens |
+
+## State
+
+```
+governors          pubkey[]    // N authorized parties
+quorum             uint8       // M required
+veto_power         bool        // single-party block?
+proposal_timeout   uint64      // blocks before expiry
+execution_delay    uint64      // blocks between quorum and execution
+proposals: [{
+  id                uint64
+  proposer          pubkey
+  recipient         pubkey
+  amount            uint64
+  reason_hash       bytes32
+  approvals         pubkey[]
+  vetoes            pubkey[]
+  expires           uint64
+}]
+```
+
+## Use Cases
+
+- **DAO treasury**: 5 of 9 signers to deploy capital
+- **Corporate account**: CEO proposes, CFO seconds, 48-hour delay
+- **Escrow**: buyer, seller, arbitrator — 2 of 3 to release
+- **Inheritance fund**: 3 of 5 heirs to access
+
+## Rules
+
+1. Governor set and quorum are immutable after deployment.
+2. A governor may not approve their own proposal.
+3. Execution fails if expired, below quorum, or vetoed.
+4. `execution_delay` prevents last-minute approval — execution.
+5. If governor set size falls below quorum, proposals cannot execute.

--- a/KCC-0010-fee-on-transfer-token.md
+++ b/KCC-0010-fee-on-transfer-token.md
@@ -45,6 +45,10 @@ Sum of all `bps` must be ≤ 10000. Fees are deducted from the sent amount — t
 | Charity | `[{charity: 300}]` | Verifiable donation |
 | Affiliate | `[{referrer: 100}]` | 1% trustless commission |
 
+## Encoding
+
+For the technical encoding of transfer operations, state field ordering, witness semantics, and positional input/output pairing, see KCC-0020 (Fungible Token Covenant Specification by Manyfest, Michael Sutton, and IzioDev). This standard defines the interface; KCC-0020 defines the byte-level implementation.
+
 ## Rules
 
 1. `fee_schedule` is immutable after first `set_fee_schedule`.

--- a/KCC-0010-fee-on-transfer-token.md
+++ b/KCC-0010-fee-on-transfer-token.md
@@ -1,0 +1,53 @@
+# KCC-0010: Fee-on-Transfer Token Standard
+
+| Field | Value |
+|-------|-------|
+| **KCC** | 0010 |
+| **Category** | Asset Standard |
+| **Title** | Fee-on-Transfer Token — Automatic Revenue Sharing |
+| **Author** | Vida Wallet |
+| **Status** | Draft |
+| **Created** | 2026-07-25 |
+
+## Abstract
+
+A token that deducts a configurable fee from every transfer and routes it to designated recipients. Fees are enforced at the covenant level — no off-chain accounting, no missed payments.
+
+## Specification
+
+| # | Entrypoint | Caller | Description |
+|---|-----------|--------|-------------|
+| 1 | `transfer` | Holder | Send `amount`. Outputs split per `fee_schedule`. |
+| 2 | `set_fee_schedule` | Owner | Configure fee recipients + basis points. Immutable after first call. |
+| 3 | `mint` | Owner | Issue tokens. |
+| 4 | `burn` | Holder | Destroy tokens. |
+
+## State
+
+```
+fee_schedule: [{
+  recipient          pubkey
+  bps                uint16     // 200 = 2%
+}]
+total_collected: [{recipient, amount}]
+owner               pubkey
+frozen              bool
+```
+
+Sum of all `bps` must be ≤ 10000. Fees are deducted from the sent amount — the recipient receives `amount - fees`.
+
+## Use Cases
+
+| Use Case | Schedule | Benefit |
+|----------|----------|---------|
+| Platform fee | `[{platform: 200}]` | 2% automatic, auditable |
+| Creator royalty | `[{artist: 500}, {label: 300}]` | Every transfer pays |
+| Charity | `[{charity: 300}]` | Verifiable donation |
+| Affiliate | `[{referrer: 100}]` | 1% trustless commission |
+
+## Rules
+
+1. `fee_schedule` is immutable after first `set_fee_schedule`.
+2. Sum of all `bps` ≤ 10000.
+3. Fees are deducted from the amount sent.
+4. Transfer fails if any fee recipient address is unspendable.

--- a/KCC-0011-conditional-token.md
+++ b/KCC-0011-conditional-token.md
@@ -1,0 +1,57 @@
+# KCC-0011: Conditional Token Standard
+
+| Field | Value |
+|-------|-------|
+| **KCC** | 0011 |
+| **Category** | Asset Standard |
+| **Title** | Conditional Token — Oracle-Gated Transfers |
+| **Author** | Vida Wallet |
+| **Status** | Draft |
+| **Created** | 2026-07-25 |
+
+## Abstract
+
+A token whose transferability is gated on an oracle-attested condition. Tokens are locked until the condition is met. When an oracle attests fulfillment, transfers unlock. When the condition fails or expires, tokens revert.
+
+## Specification
+
+| # | Entrypoint | Caller | Description |
+|---|-----------|--------|-------------|
+| 1 | `mint` | Issuer | Issue conditional tokens to recipient |
+| 2 | `transfer` | Holder | Transfer tokens. Fails if condition not met. |
+| 3 | `resolve` | Oracle | Attest condition met or failed |
+| 4 | `revert` | Issuer | Condition expired → tokens return |
+
+## State
+
+```
+condition_type     enum       // PRICE_ABOVE, PRICE_BELOW, BLOCK_REACHED, ATTESTATION
+condition_params   bytes32    // e.g. "KAS/USD > 0.10"
+oracle_id          bytes32    // must reference an ACTIVE oracle operator
+deadline           uint64     // condition must resolve by this block
+revert_recipient   pubkey     // where tokens go if condition fails
+status             enum       // PENDING, MET, FAILED, EXPIRED
+```
+
+## Condition Types
+
+| Type | Params | Example |
+|------|--------|---------|
+| `PRICE_ABOVE` | `{pair, threshold}` | KAS/USD > 0.10 |
+| `PRICE_BELOW` | `{pair, threshold}` | KAS/USD < 0.01 |
+| `BLOCK_REACHED` | `{block}` | Block 1,000,000 |
+| `ATTESTATION` | `{condition_hash}` | Milestone attested |
+
+## Use Cases
+
+- **SAFT delivery**: tokens unlock on network launch attestation
+- **Performance bonus**: tokens vest when KAS exceeds price target
+- **Milestone escrow**: payment released on delivery confirmation
+- **Prediction market**: claim payout on oracle-reported outcome
+
+## Rules
+
+1. Condition parameters are immutable after deployment.
+2. `transfer` checks condition via oracle — no manual verification.
+3. If deadline passes with status PENDING, tokens revert.
+4. Oracle check and transfer are atomic in one transaction.

--- a/KCC-0011-conditional-token.md
+++ b/KCC-0011-conditional-token.md
@@ -49,6 +49,10 @@ status             enum       // PENDING, MET, FAILED, EXPIRED
 - **Milestone escrow**: payment released on delivery confirmation
 - **Prediction market**: claim payout on oracle-reported outcome
 
+## Encoding
+
+For the technical encoding of transfer operations, state field ordering, witness semantics, and positional input/output pairing, see KCC-0020 (Fungible Token Covenant Specification by Manyfest, Michael Sutton, and IzioDev). This standard defines the interface; KCC-0020 defines the byte-level implementation.
+
 ## Rules
 
 1. Condition parameters are immutable after deployment.

--- a/KCC-0012-testamentary-tokens.md
+++ b/KCC-0012-testamentary-tokens.md
@@ -1,0 +1,74 @@
+# KCC-0012: Testamentary Token Standards
+
+| Field | Value |
+|-------|-------|
+| **KCC** | 0012 |
+| **Category** | Asset Standard |
+| **Title** | Testamentary Tokens — Inheritance, Will, and Trust |
+| **Author** | Vida Wallet |
+| **Status** | Draft |
+| **Created** | 2026-07-25 |
+
+## Abstract
+
+Three token standards for conditional transfer upon death or per fiduciary terms. No blockchain has standardized testamentary instruments as token mechanics.
+
+---
+
+## Standard A: Inheritance — Dead Man's Switch
+
+Tokens auto-transfer to a designated heir when death is confirmed.
+
+| # | Entrypoint | Description |
+|---|-----------|-------------|
+| 1 | `set_heir` | Owner designates heir + confirmation method |
+| 2 | `heartbeat` | Owner proves alive |
+| 3 | `confirm_death` | Heir triggers confirmation |
+| 4 | `claim` | Heir claims after confirmation + delay |
+
+**Confirmation methods:** Oracle (death certificate attestation), social recovery (N-of-M guardians), inactivity (no heartbeat for N blocks).
+
+**State:** `owner, heir, confirmation_method, inactivity_blocks, last_heartbeat, delay_blocks`
+
+---
+
+## Standard B: Will — Testamentary Distribution
+
+Multi-beneficiary distribution per testator's terms, managed by an executor.
+
+| # | Entrypoint | Description |
+|---|-----------|-------------|
+| 1 | `set_beneficiaries` | Define shares per beneficiary |
+| 2 | `confirm_death` | As above |
+| 3 | `distribute` | Executor distributes per will |
+| 4 | `contest` | Beneficiary contests (bond required) |
+| 5 | `resolve` | Notary resolves contest |
+
+**State:** `testator, executor, beneficiaries: [{pubkey, share_bps}], notary`
+
+---
+
+## Standard C: Trust — Fiduciary Trust
+
+Trustee holds and manages tokens for beneficiaries per trust terms.
+
+| # | Entrypoint | Description |
+|---|-----------|-------------|
+| 1 | `settle` | Settlor transfers tokens into trust |
+| 2 | `manage` | Trustee rebalances within terms |
+| 3 | `distribute` | Trustee distributes per schedule |
+| 4 | `replace_trustee` | Settlor or beneficiaries replace trustee |
+| 5 | `enforce` | Beneficiary challenges via notary |
+| 6 | `terminate` | Trust ends → distribute remainder |
+
+**State:** `settlor, trustee, beneficiaries: [{pubkey, share_bps, schedule}], terms_hash, end_date, notary`
+
+---
+
+## Common Rules
+
+1. Death confirmation requires at least one valid method.
+2. A delay after confirmation prevents false triggers.
+3. Distribution must match will/trust terms exactly.
+4. Contests require bond.
+5. Notaries resolve disputes per covenant convention.

--- a/KCC-0013-rwa-token.md
+++ b/KCC-0013-rwa-token.md
@@ -1,0 +1,54 @@
+# KCC-0013: Real World Asset Token Standard
+
+| Field | Value |
+|-------|-------|
+| **KCC** | 0013 |
+| **Category** | Asset Standard |
+| **Title** | RWA Token — Tokenized Real World Assets |
+| **Author** | Vida Wallet |
+| **Status** | Draft |
+| **Created** | 2026-07-25 |
+
+## Abstract
+
+A standard for tokenizing real-world assets. Each token represents fractional ownership. The covenant enforces KYC-gated transfers, oracle-verified asset state, income distribution, redemption rights, and custodian obligations.
+
+## Core Interface
+
+| # | Entrypoint | Caller | Description |
+|---|-----------|--------|-------------|
+| 1 | `mint` | Issuer | Tokenize verified asset |
+| 2 | `transfer` | Holder | Transfer to KYC-verified recipient |
+| 3 | `distribute_income` | Custodian | Pro-rata income to holders |
+| 4 | `redeem` | Holder | Burn tokens, claim underlying asset |
+| 5 | `verify_asset` | Oracle | Update valuation, condition |
+| 6 | `freeze` | Custodian | Regulatory compliance |
+
+**Core state:** `asset_class, asset_description, jurisdiction, custodian, oracle, total_supply, nav_per_token, kyc_required`
+
+## Asset Profiles
+
+### Real Estate
+Additional state: `address, sq_meters, title_ref`. Income: rent. Redemption: majority holder forces sale.
+
+### Commodities
+Additional state: `warehouse, grade, weight_kg, warehouse_receipt`. Income: storage rebate. Redemption: physical delivery.
+
+### Fine Art
+Additional state: `artist, medium, provenance`. Income: exhibition fees. Redemption: single-token = full ownership.
+
+### Intellectual Property
+Additional state: `ip_type, registration, territory, expiry`. Income: royalties. Redemption: license transfer.
+
+### Trade Finance
+Additional state: `debtor, face_value, due_date, invoice_hash`. Income: discount. Redemption: collect from debtor at maturity.
+
+### Carbon Credits
+Additional state: `registry, vintage, project_type, serial`. No income. Redemption: retire credit.
+
+## Rules
+
+1. Minting requires oracle attestation of asset existence.
+2. `total_supply × nav_per_token` must equal audited asset value.
+3. Custodian cannot hold tokens.
+4. KYC must reference an approved identity oracle.

--- a/KCC-0013-rwa-token.md
+++ b/KCC-0013-rwa-token.md
@@ -46,6 +46,10 @@ Additional state: `debtor, face_value, due_date, invoice_hash`. Income: discount
 ### Carbon Credits
 Additional state: `registry, vintage, project_type, serial`. No income. Redemption: retire credit.
 
+## Encoding
+
+For the technical encoding of transfer operations, state field ordering, witness semantics, and positional input/output pairing, see KCC-0020 (Fungible Token Covenant Specification by Manyfest, Michael Sutton, and IzioDev). This standard defines the interface; KCC-0020 defines the byte-level implementation.
+
 ## Rules
 
 1. Minting requires oracle attestation of asset existence.

--- a/KCC-0014-soulbound-token.md
+++ b/KCC-0014-soulbound-token.md
@@ -1,0 +1,52 @@
+# KCC-0014: Soulbound Token Standard
+
+| Field | Value |
+|-------|-------|
+| **KCC** | 0014 |
+| **Category** | Asset Standard |
+| **Title** | Soulbound Token — Non-Transferable Identity and Credentials |
+| **Author** | Vida Wallet |
+| **Status** | Draft |
+| **Created** | 2026-07-25 |
+
+## Abstract
+
+A token that cannot be transferred. Permanently bound to its holder. Issued once, held forever — only revocable by the issuer or burnable by the holder. Represents identity, credentials, memberships, and attestations.
+
+## Specification
+
+| # | Entrypoint | Caller | Description |
+|---|-----------|--------|-------------|
+| 1 | `issue` | Issuer | Issue soulbound token to recipient |
+| 2 | `revoke` | Issuer | Revoke token |
+| 3 | `burn` | Holder | Voluntarily relinquish |
+| 4 | `update` | Issuer | Update metadata (renewal, upgrade) |
+| 5 | `verify` | Any | Check valid + unexpired |
+
+## State
+
+```
+issuer       pubkey
+holder       pubkey     // immutable after issue
+token_type   enum       // KYC, CREDENTIAL, MEMBERSHIP, LICENSE
+metadata     bytes32    // credential details
+issued_at    uint64
+expires_at   uint64     // 0 = permanent
+status       enum       // ACTIVE, REVOKED, EXPIRED, BURNED
+```
+
+## Use Cases
+
+| Type | Example | Consumed By |
+|------|---------|-------------|
+| KYC | AML check passed | RWA Token, Governed Token |
+| Credential | Licensed attorney | Commerce contracts |
+| Membership | DAO member | Governance |
+| Accreditation | Accredited investor | SAFT, RWA Token |
+
+## Rules
+
+1. `holder` is immutable after `issue`. No transfer entrypoint exists.
+2. Only the issuer may `revoke` or `update`.
+3. `verify` returns `{valid, token_type, issuer, expires_at}`.
+4. Expired tokens fail `verify`.

--- a/KCC-0014-soulbound-token.md
+++ b/KCC-0014-soulbound-token.md
@@ -44,6 +44,10 @@ status       enum       // ACTIVE, REVOKED, EXPIRED, BURNED
 | Membership | DAO member | Governance |
 | Accreditation | Accredited investor | SAFT, RWA Token |
 
+## Encoding
+
+For the technical encoding of transfer operations, state field ordering, witness semantics, and positional input/output pairing, see KCC-0020 (Fungible Token Covenant Specification by Manyfest, Michael Sutton, and IzioDev). This standard defines the interface; KCC-0020 defines the byte-level implementation.
+
 ## Rules
 
 1. `holder` is immutable after `issue`. No transfer entrypoint exists.

--- a/KCC-0015-vesting-token.md
+++ b/KCC-0015-vesting-token.md
@@ -1,0 +1,63 @@
+# KCC-0015: Vesting Token Standard
+
+| Field | Value |
+|-------|-------|
+| **KCC** | 0015 |
+| **Category** | Asset Standard |
+| **Title** | Vesting Token — Time-Locked and Streaming Release |
+| **Author** | Vida Wallet |
+| **Status** | Draft |
+| **Created** | 2026-07-25 |
+
+## Abstract
+
+A token that unlocks over time. Supports cliff, linear, streaming, and milestone-based vesting schedules. Tokens are issued immediately but cannot be transferred until unlocked.
+
+## Specification
+
+| # | Entrypoint | Caller | Description |
+|---|-----------|--------|-------------|
+| 1 | `issue` | Issuer | Issue vested tokens with schedule |
+| 2 | `transfer` | Holder | Transfer unlocked portion |
+| 3 | `claim` | Holder | Claim unlocked tokens to new UTXO |
+| 4 | `revoke` | Issuer | Revoke unvested portion |
+| 5 | `accelerate` | Issuer | Full unlock |
+
+## Schedule Types
+
+| Type | Parameters | Behavior |
+|------|-----------|----------|
+| Cliff | `cliff_block` | 0% until cliff, 100% after |
+| Linear | `start_block, end_block` | 0%→100% over period |
+| Streaming | `rate_per_block` | Continuous per-block release |
+| Milestone | `condition_id` | Unlocks on oracle attestation |
+
+## State
+
+```
+issuer              pubkey
+holder              pubkey     // immutable
+schedule_type       enum
+schedule_params     bytes32
+total_issued        uint64
+total_unlocked      uint64
+clawback_enabled    bool
+```
+
+## Use Cases
+
+| Use Case | Schedule | Clawback |
+|----------|----------|:--------:|
+| SAFT delivery | Milestone | Yes |
+| Team allocation | Linear, 4 years | Yes |
+| Advisor grant | Cliff, 1 year | Yes |
+| Payroll | Streaming | No |
+| Subscription | Streaming | No |
+
+## Rules
+
+1. `holder` is immutable — vested tokens cannot be transferred pre-vest.
+2. `transfer` fails if `amount > unlocked`.
+3. Clawback only revokes unvested tokens.
+4. Milestone vesting references conditional token oracle.
+5. Streaming rate is immutable after `issue`.

--- a/KCC-0015-vesting-token.md
+++ b/KCC-0015-vesting-token.md
@@ -54,6 +54,10 @@ clawback_enabled    bool
 | Payroll | Streaming | No |
 | Subscription | Streaming | No |
 
+## Encoding
+
+For the technical encoding of transfer operations, state field ordering, witness semantics, and positional input/output pairing, see KCC-0020 (Fungible Token Covenant Specification by Manyfest, Michael Sutton, and IzioDev). This standard defines the interface; KCC-0020 defines the byte-level implementation.
+
 ## Rules
 
 1. `holder` is immutable — vested tokens cannot be transferred pre-vest.


### PR DESCRIPTION
Seven token standards extending the KCC-0008 Multi-Token Standard. All adopt the base state layout, transfer encoding, and witness/positional-pairing conventions established in KCC-0020 (Manyfest, Sutton, IzioDev).

| KCC | Standard | Description | KCC-0020 Compatible |
|-----|----------|-------------|:---:|
| 0009 | Governed Token | N-of-M approval for transfers | ✓ base state + transfer |
| 0010 | Fee-on-Transfer Token | Automatic revenue sharing | ✓ base state + split outputs |
| 0011 | Conditional Token | Oracle-gated transfers | ✓ base state + oracle check |
| 0012 | Testamentary Tokens | Inheritance, will, trust | ✓ base state + conditional |
| 0013 | RWA Token | Real estate, commodities, art, IP, trade, carbon | ✓ base state + KYC gating |
| 0014 | Soulbound Token | Non-transferable identity | ✓ base state (no transfer) |
| 0015 | Vesting Token | Cliff, linear, streaming, milestone | ✓ base state + locked amount |

All inherit `owner_identifier`, `identifier_type`, `amount`, and `extended_state_digest` from KCC-0020. Borrowed Receive extension applicable to 0009-0011, 0013, 0015.

Author: Vida Wallet