### PR TITLE
KCC-0016 and KCC-0017: Covenant ABI and Oracle Attestation Format

### DIFF
--- a/KCC-0009-governed-token.md
+++ b/KCC-0009-governed-token.md
@@ -1,0 +1,72 @@
+# KCC-0009: Governed Token Standard
+
+| Field | Value |
+|-------|-------|
+| **KCC** | 0009 |
+| **Category** | Asset Standard |
+| **Title** | Governed Token — Multi-Party Approval for Transfers |
+| **Author** | Vida Wallet |
+| **Status** | Draft |
+| **Created** | 2026-07-25 |
+
+## Abstract
+
+A token requiring N-of-M authorized parties to approve every transfer. The governance lives in the token itself — not in a wallet wrapper. No single party can move funds. This does not exist as a standard on any blockchain.
+
+## Motivation
+
+Existing multisig wallets control entire accounts. A governed token controls the asset. Four differences:
+
+| | Multisig Wallet | Governed Token |
+|---|---|---|
+| Control scope | All assets in wallet | This token only |
+| Audit trail | Wallet transactions | Per-proposal on-chain |
+| Recovery | Key rotation | Governor set change (requires quorum) |
+| Composability | None — wallet-level | Covenant composable with commerce contracts |
+
+## Specification
+
+| # | Entrypoint | Caller | Description |
+|---|-----------|--------|-------------|
+| 1 | `propose` | Governor | Propose `amount` → `recipient` with `reason_hash` |
+| 2 | `second` | Governor | Second the proposal. Must differ from proposer. |
+| 3 | `veto` | Governor | Block proposal if veto power is configured |
+| 4 | `execute` | Any | Quorum reached, delay elapsed → transfer executes |
+| 5 | `cancel` | Proposer | Withdraw pending proposal |
+| 6 | `mint` | Owner | Create tokens |
+| 7 | `burn` | Owner | Destroy tokens |
+
+## State
+
+```
+governors          pubkey[]    // N authorized parties
+quorum             uint8       // M required
+veto_power         bool        // single-party block?
+proposal_timeout   uint64      // blocks before expiry
+execution_delay    uint64      // blocks between quorum and execution
+proposals: [{
+  id                uint64
+  proposer          pubkey
+  recipient         pubkey
+  amount            uint64
+  reason_hash       bytes32
+  approvals         pubkey[]
+  vetoes            pubkey[]
+  expires           uint64
+}]
+```
+
+## Use Cases
+
+- **DAO treasury**: 5 of 9 signers to deploy capital
+- **Corporate account**: CEO proposes, CFO seconds, 48-hour delay
+- **Escrow**: buyer, seller, arbitrator — 2 of 3 to release
+- **Inheritance fund**: 3 of 5 heirs to access
+
+## Rules
+
+1. Governor set and quorum are immutable after deployment.
+2. A governor may not approve their own proposal.
+3. Execution fails if expired, below quorum, or vetoed.
+4. `execution_delay` prevents last-minute approval — execution.
+5. If governor set size falls below quorum, proposals cannot execute.

--- a/KCC-0010-fee-on-transfer-token.md
+++ b/KCC-0010-fee-on-transfer-token.md
@@ -1,0 +1,53 @@
+# KCC-0010: Fee-on-Transfer Token Standard
+
+| Field | Value |
+|-------|-------|
+| **KCC** | 0010 |
+| **Category** | Asset Standard |
+| **Title** | Fee-on-Transfer Token — Automatic Revenue Sharing |
+| **Author** | Vida Wallet |
+| **Status** | Draft |
+| **Created** | 2026-07-25 |
+
+## Abstract
+
+A token that deducts a configurable fee from every transfer and routes it to designated recipients. Fees are enforced at the covenant level — no off-chain accounting, no missed payments.
+
+## Specification
+
+| # | Entrypoint | Caller | Description |
+|---|-----------|--------|-------------|
+| 1 | `transfer` | Holder | Send `amount`. Outputs split per `fee_schedule`. |
+| 2 | `set_fee_schedule` | Owner | Configure fee recipients + basis points. Immutable after first call. |
+| 3 | `mint` | Owner | Issue tokens. |
+| 4 | `burn` | Holder | Destroy tokens. |
+
+## State
+
+```
+fee_schedule: [{
+  recipient          pubkey
+  bps                uint16     // 200 = 2%
+}]
+total_collected: [{recipient, amount}]
+owner               pubkey
+frozen              bool
+```
+
+Sum of all `bps` must be ≤ 10000. Fees are deducted from the sent amount — the recipient receives `amount - fees`.
+
+## Use Cases
+
+| Use Case | Schedule | Benefit |
+|----------|----------|---------|
+| Platform fee | `[{platform: 200}]` | 2% automatic, auditable |
+| Creator royalty | `[{artist: 500}, {label: 300}]` | Every transfer pays |
+| Charity | `[{charity: 300}]` | Verifiable donation |
+| Affiliate | `[{referrer: 100}]` | 1% trustless commission |
+
+## Rules
+
+1. `fee_schedule` is immutable after first `set_fee_schedule`.
+2. Sum of all `bps` ≤ 10000.
+3. Fees are deducted from the amount sent.
+4. Transfer fails if any fee recipient address is unspendable.

--- a/KCC-0011-conditional-token.md
+++ b/KCC-0011-conditional-token.md
@@ -1,0 +1,57 @@
+# KCC-0011: Conditional Token Standard
+
+| Field | Value |
+|-------|-------|
+| **KCC** | 0011 |
+| **Category** | Asset Standard |
+| **Title** | Conditional Token — Oracle-Gated Transfers |
+| **Author** | Vida Wallet |
+| **Status** | Draft |
+| **Created** | 2026-07-25 |
+
+## Abstract
+
+A token whose transferability is gated on an oracle-attested condition. Tokens are locked until the condition is met. When an oracle attests fulfillment, transfers unlock. When the condition fails or expires, tokens revert.
+
+## Specification
+
+| # | Entrypoint | Caller | Description |
+|---|-----------|--------|-------------|
+| 1 | `mint` | Issuer | Issue conditional tokens to recipient |
+| 2 | `transfer` | Holder | Transfer tokens. Fails if condition not met. |
+| 3 | `resolve` | Oracle | Attest condition met or failed |
+| 4 | `revert` | Issuer | Condition expired → tokens return |
+
+## State
+
+```
+condition_type     enum       // PRICE_ABOVE, PRICE_BELOW, BLOCK_REACHED, ATTESTATION
+condition_params   bytes32    // e.g. "KAS/USD > 0.10"
+oracle_id          bytes32    // must reference an ACTIVE oracle operator
+deadline           uint64     // condition must resolve by this block
+revert_recipient   pubkey     // where tokens go if condition fails
+status             enum       // PENDING, MET, FAILED, EXPIRED
+```
+
+## Condition Types
+
+| Type | Params | Example |
+|------|--------|---------|
+| `PRICE_ABOVE` | `{pair, threshold}` | KAS/USD > 0.10 |
+| `PRICE_BELOW` | `{pair, threshold}` | KAS/USD < 0.01 |
+| `BLOCK_REACHED` | `{block}` | Block 1,000,000 |
+| `ATTESTATION` | `{condition_hash}` | Milestone attested |
+
+## Use Cases
+
+- **SAFT delivery**: tokens unlock on network launch attestation
+- **Performance bonus**: tokens vest when KAS exceeds price target
+- **Milestone escrow**: payment released on delivery confirmation
+- **Prediction market**: claim payout on oracle-reported outcome
+
+## Rules
+
+1. Condition parameters are immutable after deployment.
+2. `transfer` checks condition via oracle — no manual verification.
+3. If deadline passes with status PENDING, tokens revert.
+4. Oracle check and transfer are atomic in one transaction.

--- a/KCC-0012-testamentary-tokens.md
+++ b/KCC-0012-testamentary-tokens.md
@@ -1,0 +1,74 @@
+# KCC-0012: Testamentary Token Standards
+
+| Field | Value |
+|-------|-------|
+| **KCC** | 0012 |
+| **Category** | Asset Standard |
+| **Title** | Testamentary Tokens — Inheritance, Will, and Trust |
+| **Author** | Vida Wallet |
+| **Status** | Draft |
+| **Created** | 2026-07-25 |
+
+## Abstract
+
+Three token standards for conditional transfer upon death or per fiduciary terms. No blockchain has standardized testamentary instruments as token mechanics.
+
+---
+
+## Standard A: Inheritance — Dead Man's Switch
+
+Tokens auto-transfer to a designated heir when death is confirmed.
+
+| # | Entrypoint | Description |
+|---|-----------|-------------|
+| 1 | `set_heir` | Owner designates heir + confirmation method |
+| 2 | `heartbeat` | Owner proves alive |
+| 3 | `confirm_death` | Heir triggers confirmation |
+| 4 | `claim` | Heir claims after confirmation + delay |
+
+**Confirmation methods:** Oracle (death certificate attestation), social recovery (N-of-M guardians), inactivity (no heartbeat for N blocks).
+
+**State:** `owner, heir, confirmation_method, inactivity_blocks, last_heartbeat, delay_blocks`
+
+---
+
+## Standard B: Will — Testamentary Distribution
+
+Multi-beneficiary distribution per testator's terms, managed by an executor.
+
+| # | Entrypoint | Description |
+|---|-----------|-------------|
+| 1 | `set_beneficiaries` | Define shares per beneficiary |
+| 2 | `confirm_death` | As above |
+| 3 | `distribute` | Executor distributes per will |
+| 4 | `contest` | Beneficiary contests (bond required) |
+| 5 | `resolve` | Notary resolves contest |
+
+**State:** `testator, executor, beneficiaries: [{pubkey, share_bps}], notary`
+
+---
+
+## Standard C: Trust — Fiduciary Trust
+
+Trustee holds and manages tokens for beneficiaries per trust terms.
+
+| # | Entrypoint | Description |
+|---|-----------|-------------|
+| 1 | `settle` | Settlor transfers tokens into trust |
+| 2 | `manage` | Trustee rebalances within terms |
+| 3 | `distribute` | Trustee distributes per schedule |
+| 4 | `replace_trustee` | Settlor or beneficiaries replace trustee |
+| 5 | `enforce` | Beneficiary challenges via notary |
+| 6 | `terminate` | Trust ends → distribute remainder |
+
+**State:** `settlor, trustee, beneficiaries: [{pubkey, share_bps, schedule}], terms_hash, end_date, notary`
+
+---
+
+## Common Rules
+
+1. Death confirmation requires at least one valid method.
+2. A delay after confirmation prevents false triggers.
+3. Distribution must match will/trust terms exactly.
+4. Contests require bond.
+5. Notaries resolve disputes per covenant convention.

--- a/KCC-0013-rwa-token.md
+++ b/KCC-0013-rwa-token.md
@@ -1,0 +1,54 @@
+# KCC-0013: Real World Asset Token Standard
+
+| Field | Value |
+|-------|-------|
+| **KCC** | 0013 |
+| **Category** | Asset Standard |
+| **Title** | RWA Token — Tokenized Real World Assets |
+| **Author** | Vida Wallet |
+| **Status** | Draft |
+| **Created** | 2026-07-25 |
+
+## Abstract
+
+A standard for tokenizing real-world assets. Each token represents fractional ownership. The covenant enforces KYC-gated transfers, oracle-verified asset state, income distribution, redemption rights, and custodian obligations.
+
+## Core Interface
+
+| # | Entrypoint | Caller | Description |
+|---|-----------|--------|-------------|
+| 1 | `mint` | Issuer | Tokenize verified asset |
+| 2 | `transfer` | Holder | Transfer to KYC-verified recipient |
+| 3 | `distribute_income` | Custodian | Pro-rata income to holders |
+| 4 | `redeem` | Holder | Burn tokens, claim underlying asset |
+| 5 | `verify_asset` | Oracle | Update valuation, condition |
+| 6 | `freeze` | Custodian | Regulatory compliance |
+
+**Core state:** `asset_class, asset_description, jurisdiction, custodian, oracle, total_supply, nav_per_token, kyc_required`
+
+## Asset Profiles
+
+### Real Estate
+Additional state: `address, sq_meters, title_ref`. Income: rent. Redemption: majority holder forces sale.
+
+### Commodities
+Additional state: `warehouse, grade, weight_kg, warehouse_receipt`. Income: storage rebate. Redemption: physical delivery.
+
+### Fine Art
+Additional state: `artist, medium, provenance`. Income: exhibition fees. Redemption: single-token = full ownership.
+
+### Intellectual Property
+Additional state: `ip_type, registration, territory, expiry`. Income: royalties. Redemption: license transfer.
+
+### Trade Finance
+Additional state: `debtor, face_value, due_date, invoice_hash`. Income: discount. Redemption: collect from debtor at maturity.
+
+### Carbon Credits
+Additional state: `registry, vintage, project_type, serial`. No income. Redemption: retire credit.
+
+## Rules
+
+1. Minting requires oracle attestation of asset existence.
+2. `total_supply × nav_per_token` must equal audited asset value.
+3. Custodian cannot hold tokens.
+4. KYC must reference an approved identity oracle.

--- a/KCC-0014-soulbound-token.md
+++ b/KCC-0014-soulbound-token.md
@@ -1,0 +1,52 @@
+# KCC-0014: Soulbound Token Standard
+
+| Field | Value |
+|-------|-------|
+| **KCC** | 0014 |
+| **Category** | Asset Standard |
+| **Title** | Soulbound Token — Non-Transferable Identity and Credentials |
+| **Author** | Vida Wallet |
+| **Status** | Draft |
+| **Created** | 2026-07-25 |
+
+## Abstract
+
+A token that cannot be transferred. Permanently bound to its holder. Issued once, held forever — only revocable by the issuer or burnable by the holder. Represents identity, credentials, memberships, and attestations.
+
+## Specification
+
+| # | Entrypoint | Caller | Description |
+|---|-----------|--------|-------------|
+| 1 | `issue` | Issuer | Issue soulbound token to recipient |
+| 2 | `revoke` | Issuer | Revoke token |
+| 3 | `burn` | Holder | Voluntarily relinquish |
+| 4 | `update` | Issuer | Update metadata (renewal, upgrade) |
+| 5 | `verify` | Any | Check valid + unexpired |
+
+## State
+
+```
+issuer       pubkey
+holder       pubkey     // immutable after issue
+token_type   enum       // KYC, CREDENTIAL, MEMBERSHIP, LICENSE
+metadata     bytes32    // credential details
+issued_at    uint64
+expires_at   uint64     // 0 = permanent
+status       enum       // ACTIVE, REVOKED, EXPIRED, BURNED
+```
+
+## Use Cases
+
+| Type | Example | Consumed By |
+|------|---------|-------------|
+| KYC | AML check passed | RWA Token, Governed Token |
+| Credential | Licensed attorney | Commerce contracts |
+| Membership | DAO member | Governance |
+| Accreditation | Accredited investor | SAFT, RWA Token |
+
+## Rules
+
+1. `holder` is immutable after `issue`. No transfer entrypoint exists.
+2. Only the issuer may `revoke` or `update`.
+3. `verify` returns `{valid, token_type, issuer, expires_at}`.
+4. Expired tokens fail `verify`.

--- a/KCC-0015-vesting-token.md
+++ b/KCC-0015-vesting-token.md
@@ -1,0 +1,63 @@
+# KCC-0015: Vesting Token Standard
+
+| Field | Value |
+|-------|-------|
+| **KCC** | 0015 |
+| **Category** | Asset Standard |
+| **Title** | Vesting Token — Time-Locked and Streaming Release |
+| **Author** | Vida Wallet |
+| **Status** | Draft |
+| **Created** | 2026-07-25 |
+
+## Abstract
+
+A token that unlocks over time. Supports cliff, linear, streaming, and milestone-based vesting schedules. Tokens are issued immediately but cannot be transferred until unlocked.
+
+## Specification
+
+| # | Entrypoint | Caller | Description |
+|---|-----------|--------|-------------|
+| 1 | `issue` | Issuer | Issue vested tokens with schedule |
+| 2 | `transfer` | Holder | Transfer unlocked portion |
+| 3 | `claim` | Holder | Claim unlocked tokens to new UTXO |
+| 4 | `revoke` | Issuer | Revoke unvested portion |
+| 5 | `accelerate` | Issuer | Full unlock |
+
+## Schedule Types
+
+| Type | Parameters | Behavior |
+|------|-----------|----------|
+| Cliff | `cliff_block` | 0% until cliff, 100% after |
+| Linear | `start_block, end_block` | 0%→100% over period |
+| Streaming | `rate_per_block` | Continuous per-block release |
+| Milestone | `condition_id` | Unlocks on oracle attestation |
+
+## State
+
+```
+issuer              pubkey
+holder              pubkey     // immutable
+schedule_type       enum
+schedule_params     bytes32
+total_issued        uint64
+total_unlocked      uint64
+clawback_enabled    bool
+```
+
+## Use Cases
+
+| Use Case | Schedule | Clawback |
+|----------|----------|:--------:|
+| SAFT delivery | Milestone | Yes |
+| Team allocation | Linear, 4 years | Yes |
+| Advisor grant | Cliff, 1 year | Yes |
+| Payroll | Streaming | No |
+| Subscription | Streaming | No |
+
+## Rules
+
+1. `holder` is immutable — vested tokens cannot be transferred pre-vest.
+2. `transfer` fails if `amount > unlocked`.
+3. Clawback only revokes unvested tokens.
+4. Milestone vesting references conditional token oracle.
+5. Streaming rate is immutable after `issue`.

--- a/KCC-0016-covenant-abi.md
+++ b/KCC-0016-covenant-abi.md
@@ -1,0 +1,90 @@
+# KCC-0016: Covenant ABI
+
+| Field | Value |
+|-------|-------|
+| **KCC** | 0016 |
+| **Category** | Interoperability |
+| **Title** | Covenant ABI — Interface Discovery for Tooling |
+| **Author** | Vida Wallet |
+| **Status** | Draft |
+| **Created** | 2026-07-25 |
+
+## Abstract
+
+A standard format for covenants to declare their interface — entrypoints, parameters, state fields, and metadata — so that explorers, wallets, DEXes, and indexers can auto-discover and interact with any covenant without manual integration. Complements the KCC-0020 descriptor format.
+
+## Motivation
+
+Without a standard interface declaration, every tool must be hand-coded for every covenant. A wallet cannot display token balances without knowing the state layout. A DEX cannot list a pair without knowing the transfer entrypoint signature. An explorer cannot decode a transaction without knowing parameter types. This convention makes every covenant self-describing.
+
+## Specification
+
+A Covenant ABI is a JSON document published alongside a covenant. It may be embedded in the descriptor (per KCC-0020) or served separately.
+
+### ABI Structure
+
+```json
+{
+  "covenant_id": "0xf3a...",
+  "name": "GovernedToken",
+  "version": 1,
+  "entrypoints": [{
+    "name": "transfer",
+    "params": [
+      {"name": "to", "type": "pubkey"},
+      {"name": "amount", "type": "uint64"}
+    ],
+    "returns": "void",
+    "description": "Transfer tokens to recipient"
+  }],
+  "state": [
+    {"name": "owner", "type": "pubkey"},
+    {"name": "balance", "type": "uint64"}
+  ],
+  "events": ["Transfer", "Approval", "Mint"],
+  "extensions": ["kcc20_borrowed_receive_v1"],
+  "metadata": {
+    "author": "Vida Wallet",
+    "license": "MIT",
+    "repository": "https://github.com/..."
+  }
+}
+```
+
+### Type System
+
+| Type | Description | JSON Encoding |
+|------|-------------|---------------|
+| `pubkey` | Kaspa public key | hex string |
+| `uint8`-`uint64` | Unsigned integer | number |
+| `bool` | Boolean | true/false |
+| `bytes32` | 32-byte value | hex string |
+| `enum` | Enumerated value | string name |
+| `pubkey[]` | Array of public keys | array of hex strings |
+
+### Entrypoint Signatures
+
+Each entrypoint declares its parameters with types. This enables:
+
+- **Wallets** to construct calls without knowing the covenant internally
+- **Explorers** to decode transaction input data
+- **DEXes** to discover which entrypoint is the transfer function
+- **Indexers** to parse state changes from transaction outputs
+
+### Event Declaration
+
+Covenants declare which events they emit. Events are recorded on-chain via structured data in transaction outputs. Tooling indexes these for notifications and activity feeds.
+
+## Convention Rules
+
+1. The ABI must be published at the same time as the covenant.
+2. Parameter types must use the standard type system defined above.
+3. State field ordering in the ABI must match the on-chain ordering.
+4. Events must be declared in the ABI to be considered part of the interface.
+5. The ABI is versioned — breaking changes increment the version number.
+
+## Relationship to Other Standards
+
+- **KCC-0020**: The ABI can be embedded in or linked from the KCC-0020 descriptor. The descriptor defines encoding; the ABI defines semantics.
+- **KCC-0008**: Multi-Token Standard covenants publish an ABI so wallets auto-detect token profiles.
+- **kascov**: The covenant explorer reads ABIs to decode transaction data without per-covenant configuration.

--- a/KCC-0017-oracle-attestation-format.md
+++ b/KCC-0017-oracle-attestation-format.md
@@ -78,7 +78,7 @@ Multiple attestations for different pairs may be bundled in one transaction. The
 
 ## Oracle Registry Reference
 
-This format references KCC-0001 (Oracle Registry Covenant Convention) for operator registration and verification. A compliant oracle network must maintain an Oracle Registry covenant. Operators must be ACTIVE. Attestations must be signed with the operator's registry-linked SECP256k1 key.
+This format references KCC-0018 (Oracle Registry) for operator registration and verification. A compliant oracle network must maintain an Oracle Registry covenant. Operators must be ACTIVE. Attestations must be signed with the operator's registry-linked SECP256k1 key.
 
 ## Convention Rules
 

--- a/KCC-0017-oracle-attestation-format.md
+++ b/KCC-0017-oracle-attestation-format.md
@@ -1,0 +1,91 @@
+# KCC-0017: Oracle Attestation Format
+
+| Field | Value |
+|-------|-------|
+| **KCC** | 0017 |
+| **Category** | Interoperability |
+| **Title** | Oracle Attestation Format — Signed Price Data Standard |
+| **Author** | Vida Wallet |
+| **Status** | Draft |
+| **Created** | 2026-07-25 |
+
+## Abstract
+
+A standard binary format for oracle-signed attestations. Defines the structure that every oracle operator signs and every covenant verifies. Enables any oracle operator to produce attestations that any covenant can consume, regardless of which oracle network they belong to.
+
+## Motivation
+
+Conditional tokens, commerce contracts, and price-gated transfers all depend on oracle attestations. Without a standard attestation format, every oracle network produces data in its own format and every covenant must be hard-coded to a specific oracle. This convention makes attestations interchangeable — a covenant written against this format can consume attestations from any compliant oracle.
+
+## Attestation Structure
+
+An attestation is a binary blob signed by the oracle operator's key. The signed payload is:
+
+```
+[version: 1 byte]
+[pair: 32 bytes]          // "KAS/USD\0\0\0\0..." null-padded
+[price_numerator: 8 bytes] // big-endian uint64
+[price_denominator: 8 bytes] // big-endian uint64, 1 for direct prices
+[timestamp: 8 bytes]       // Unix milliseconds, big-endian uint64
+[block_height: 8 bytes]    // Kaspa block at time of observation
+[nonce: 8 bytes]           // monotonic, operator-specific
+[operator_id: 32 bytes]    // public key or covenant ID
+[signature: 64 bytes]      // SECP256k1 signature over all preceding bytes
+```
+
+Total: 161 bytes.
+
+### Fields
+
+| Field | Bytes | Description |
+|-------|:-----:|-------------|
+| version | 1 | Format version (0x01) |
+| pair | 32 | Trading pair, ASCII, null-padded |
+| price_numerator | 8 | Price numerator, big-endian uint64 |
+| price_denominator | 8 | Price denominator. 1 = direct price. e.g. for $0.02731: numerator=2731, denominator=100000 |
+| timestamp | 8 | Observation time, Unix milliseconds |
+| block_height | 8 | Kaspa block at observation |
+| nonce | 8 | Monotonic, operator-specific |
+| operator_id | 32 | Operator public key (32 bytes, SECP256k1 compressed) |
+| signature | 64 | SECP256k1 signature over bytes 0-96 |
+
+### Price Encoding
+
+Prices are encoded as a rational number: numerator / denominator. This avoids floating-point errors and enables precise representation of any price.
+
+Examples:
+- KAS/USD = $0.02731 → numerator=2731, denominator=100000
+- BTC/USD = $85,432.50 → numerator=8543250, denominator=100
+- KAS/BTC = 0.00000032 → numerator=32, denominator=100000000
+
+### Verification
+
+A covenant verifies an attestation by:
+
+1. **Format check**: version = 0x01, total length = 161 bytes
+2. **Freshness check**: `block_height` must be within the covenant's max attestation age
+3. **Pair match**: `pair` must match the expected trading pair
+4. **Signature verification**: recover public key from `signature`, verify it matches `operator_id`
+5. **Operator check**: `operator_id` must be ACTIVE in the Oracle Registry (per KCC-0001)
+
+### Nonce
+
+The nonce is a monotonically increasing counter per operator. Covenants may enforce `nonce_i > nonce_{i-1}` to prevent replay of old attestations. The nonce is operator-specific — different operators may have different nonce sequences.
+
+## Attestation Bundles
+
+Multiple attestations for different pairs may be bundled in one transaction. The format is simply concatenated attestation blobs. A covenant consuming the bundle parses each blob and selects the one matching its required pair.
+
+## Oracle Registry Reference
+
+This format references KCC-0001 (Oracle Registry Covenant Convention) for operator registration and verification. A compliant oracle network must maintain an Oracle Registry covenant. Operators must be ACTIVE. Attestations must be signed with the operator's registry-linked SECP256k1 key.
+
+## Convention Rules
+
+1. All attestations must use version 0x01.
+2. Pair names must be ASCII, null-padded to 32 bytes.
+3. Price must be a rational number. Denominator must never be zero.
+4. Timestamp must be monotonic per operator.
+5. Nonce must be monotonic per operator.
+6. Operator ID must be the compressed SECP256k1 public key (33 bytes, dropping the leading 0x02/0x03 prefix → 32 bytes).
+7. Signature covers bytes 0-96 (everything before the signature field).


### PR DESCRIPTION
Two interoperability standards.

**KCC-0016: Covenant ABI** — standard JSON format for covenants to declare their interface (entrypoints, parameters, state fields, events). Enables kascov, wallets, and DEXes to auto-discover covenant interfaces without manual integration. Compatible with KCC-0020 descriptor format.

**KCC-0017: Oracle Attestation Format** — 161-byte signed binary blob. Versioned, rational price encoding (numerator/denominator), nonce replay protection, SECP256k1 signatures. Compatible with KCC-0001 Oracle Registry. Any covenant can verify any compliant oracle attestation.

Author: Vida Wallet