### PR TITLE
Clarify KCC20 extended state fungibility semantics

### DIFF
--- a/kcc-0020.md
+++ b/kcc-0020.md
@@ -48,7 +48,7 @@ KCC20State {
 - `borrow_guard` contains the scheme-specific 32-byte guard: an amount
   threshold, a Schnorr public key, the current hash-chain value, or unused bytes
   when borrowing is disabled.
-- `extension_commitment` is a 32-byte digest of the token-specific extended
+- `extension_commitment` is a 32-byte digest of the application-specific extended
   state. The extended state itself is not stored directly in the KCC20 state.
   See [Section 4, State Extendability](#4-state-extendability) and KCC1 Section
   10 [[1]](#ref-1).
@@ -128,9 +128,9 @@ preservation and all successor states.
 The transfer is bounded by `max_token_inputs` and `max_token_outputs`, which
 limit the number of KCC20 states consumed and created by the transfer.
 
-Extended state is opaque to the transfer: `extension_commitment` must be
-preserved unchanged. When multiple inputs are consolidated into one successor
-state, they must have the same `extension_commitment`.
+Extended state is opaque to the transfer. All inputs and continuation outputs
+participating in a standard transfer must have the same
+`extension_commitment`, which must be preserved unchanged.
 
 These layouts apply KCC2's minimum approval checks. A non-default configuration
 may override them, in which case the Program ABI must describe how each
@@ -186,14 +186,24 @@ three enabled borrow schemes.
 ## 4. State Extendability
 
 A KCC20 covenant may extend its base state through `extension_commitment`. This
-field stores a digest of the token-specific extended state rather than the
+field stores a digest of application-specific extended state rather than the
 extended state itself. The artifact must describe the extended state's type and
 encoding, and how its digest is calculated and verified, following KCC1 Section
 10 [[1]](#ref-1).
 
-The standard transfer treats extended state as opaque and preserves
-`extension_commitment` unchanged in successor states. A KCC20 covenant may
-expose a separate program-specific entrypoint that updates extended state.
+Extended state allows a covenant to extend token identity beyond the base KCC20
+state. It may represent sub-tokens, types, variants, status flags, restrictions,
+or other properties defined by the covenant.
+
+For the standard transfer, extended state forms part of the token identity
+relevant to fungibility. Within a KCC20 covenant family, states are considered
+fungible with one another only when their `extension_commitment` values are
+identical. The transfer does not interpret what the extended state represents;
+it treats the commitment as opaque and preserves it unchanged.
+
+In addition to the standard transfer entrypoints, a KCC20 covenant may expose
+covenant-specific entrypoints that interpret or update extended state according
+to the covenant's own rules.
 
 ## 5. Borrowed Receive
 


### PR DESCRIPTION
Clarifies the purpose of `extension_commitment` and its relationship to fungibility.

