### PR TITLE
KCC-0020: prevent hash-chain borrow front-running

### DIFF
--- a/kcc-0020.md
+++ b/kcc-0020.md
@@ -248,6 +248,7 @@ guard. Let `leader_state` be the state of the active leader input, and let
 
 ```text
 amount_threshold = 0
+next_borrow_guard = borrow_guard
 
 if borrow_scheme == disabled/v1:
     reject
@@ -256,10 +257,10 @@ else if borrow_scheme == amount-threshold/v1:
 else if borrow_scheme == schnorr-signature/v1:
     verify borrow_witness with the public key in borrow_guard
 else if borrow_scheme == hash-chain/v1:
-    parse next_borrow_guard, one_time_pubkey, borrow_signature
+    parse revealed_guard, one_time_pubkey, borrow_signature
         from borrow_witness
-    require(Hash(next_borrow_guard || one_time_pubkey) == borrow_guard)
-    require(next_states[0].borrow_guard == next_borrow_guard)
+    require(Hash(revealed_guard || one_time_pubkey) == borrow_guard)
+    next_borrow_guard = revealed_guard
     verify borrow_signature with one_time_pubkey
 else:
     reject
@@ -267,6 +268,7 @@ else:
 amount_difference = next_states[0].amount - leader_state.amount
 require(amount_difference > amount_threshold)
 require(next_states[0].borrow_scheme == leader_state.borrow_scheme)
+require(next_states[0].borrow_guard == next_borrow_guard)
 ```
 
 Every borrowed receive must increase the borrowed state's token amount. For

--- a/kcc-0020.md
+++ b/kcc-0020.md
@@ -255,6 +255,7 @@ else:
 
 amount_difference = next_states[0].amount - leader_state.amount
 require(amount_difference > amount_threshold)
+require(next_states[0].borrow_scheme == leader_state.borrow_scheme)
 require(next_states[0].borrow_guard == next_borrow_guard)
 ```
 
@@ -269,9 +270,9 @@ sufficient. For the `amount-threshold/v1` scheme, the increase must be strictly
 greater than the configured threshold.
 
 The borrowed successor must preserve `owner`, `owner_scheme`, `borrow_scheme`,
-and `extension_commitment`. It must use the expected
-`next_borrow_guard`. The actual covenant-family output corresponding to
-`next_states[0]` must have at least the KAS value of the borrowed input.
+and `extension_commitment`. It must use the expected `next_borrow_guard`. The
+actual covenant-family output corresponding to `next_states[0]` must have at
+least the KAS value of the borrowed input.
 
 The leader must preserve the total token amount across the KCC20
 covenant family. All other inputs in that family use `transfer_delegator` and

--- a/kcc-0020.md
+++ b/kcc-0020.md
@@ -6,7 +6,7 @@ Authors: Sivan Helfer <sivan@manyfest.dev>, Michael Sutton <msutton@cs.huji.ac.i
 Comments-URI: https://kas-smiths.org/t/fungible-token-covenant-specification-kcc20/8/
 Status: Draft
 Created: 2026-07-15
-Updated: 2026-08-21
+Updated: 2026-08-25
 ```
 
 # Fungible Token Covenant Specification
@@ -46,8 +46,8 @@ KCC20State {
 - `borrow_scheme` selects the rule for borrowing this state as defined in
   [Section 5, Borrowed Receive](#5-borrowed-receive).
 - `borrow_guard` contains the scheme-specific 32-byte guard: an amount
-  threshold, a Schnorr public key, the current hash-chain value, or unused bytes
-  when borrowing is disabled.
+  threshold, a Schnorr public key, the current hash-chain commitment, or unused
+  bytes when borrowing is disabled.
 - `extension_commitment` is a 32-byte digest of the token-specific extended
   state. The extended state itself is not stored directly in the KCC20 state.
   See [Section 4, State Extendability](#4-state-extendability) and KCC1 Section
@@ -218,13 +218,22 @@ The borrow schemes are:
 | `0x00` | `disabled/v1` | Unused | Borrowing is rejected |
 | `0x01` | `amount-threshold/v1` | The first eight bytes contain the threshold that the token increase must exceed | Empty |
 | `0x02` | `schnorr-signature/v1` | A 32-byte Schnorr public key | A 65-byte Schnorr transaction signature |
-| `0x03` | `hash-chain/v1` | The current 32-byte hash | Its 32-byte preimage |
+| `0x03` | `hash-chain/v1` | The current 32-byte hash-chain commitment | A 32-byte preimage, 32-byte one-time Schnorr public key, and 65-byte Schnorr transaction signature |
 
 For a borrowed receive, `borrow_witness = witness[1..]`. For the
 `amount-threshold/v1` scheme, the first eight bytes of `borrow_guard` are a
-non-negative KCC1 `int` payload; only those eight bytes are used. The selected
-scheme sets the amount threshold and the expected next borrow guard. Let
-`leader_state` be the state of the active leader input:
+non-negative KCC1 `int` payload; only those eight bytes are used.
+
+For `hash-chain/v1`, `borrow_witness` is exactly 129 bytes, laid out as:
+
+```text
+next_borrow_guard: byte[32]
+one_time_pubkey:   pubkey
+borrow_signature: sig
+```
+
+The selected scheme sets the amount threshold and the expected next borrow
+guard. Let `leader_state` be the state of the active leader input:
 
 ```text
 amount_threshold = 0
@@ -237,8 +246,10 @@ else if borrow_scheme == amount-threshold/v1:
 else if borrow_scheme == schnorr-signature/v1:
     verify borrow_witness with the public key in borrow_guard
 else if borrow_scheme == hash-chain/v1:
-    require(Hash(borrow_witness) == borrow_guard)
-    next_borrow_guard = borrow_witness
+    parse next_borrow_guard, one_time_pubkey, borrow_signature
+        from borrow_witness
+    require(Hash(next_borrow_guard || one_time_pubkey) == borrow_guard)
+    verify borrow_signature with one_time_pubkey
 else:
     reject
 
@@ -247,11 +258,15 @@ require(amount_difference > amount_threshold)
 require(next_states[0].borrow_guard == next_borrow_guard)
 ```
 
-`Hash` is the KCC1 Hash Function. Every borrowed receive must increase the
-borrowed state's token amount. For the `schnorr-signature/v1` and
-`hash-chain/v1` schemes, any positive increase is sufficient. For the
-`amount-threshold/v1` scheme, the increase must be strictly greater than the
-configured threshold.
+`Hash` is the KCC1 Hash Function. Every borrow signature used by
+`schnorr-signature/v1` or `hash-chain/v1` must be a `SIGHASH_ALL` Schnorr
+transaction signature that commits to the complete borrowed-receive
+transaction.
+
+Every borrowed receive must increase the borrowed state's token amount. For
+the `schnorr-signature/v1` and `hash-chain/v1` schemes, any positive increase is
+sufficient. For the `amount-threshold/v1` scheme, the increase must be strictly
+greater than the configured threshold.
 
 The borrowed successor must preserve `owner`, `owner_scheme`, `borrow_scheme`,
 and `extension_commitment`. It must use the expected

--- a/kcc-0020.md
+++ b/kcc-0020.md
@@ -233,11 +233,11 @@ borrow_signature: sig
 ```
 
 The selected scheme sets the amount threshold and the expected next borrow
-guard. Let `leader_state` be the state of the active leader input:
+guard. Let `leader_state` be the state of the active leader input, and let
+`Hash` be the KCC1 hash function (unkeyed BLAKE3):
 
 ```text
 amount_threshold = 0
-next_borrow_guard = borrow_guard
 
 if borrow_scheme == disabled/v1:
     reject
@@ -249,6 +249,7 @@ else if borrow_scheme == hash-chain/v1:
     parse next_borrow_guard, one_time_pubkey, borrow_signature
         from borrow_witness
     require(Hash(next_borrow_guard || one_time_pubkey) == borrow_guard)
+    require(next_states[0].borrow_guard == next_borrow_guard)
     verify borrow_signature with one_time_pubkey
 else:
     reject
@@ -256,13 +257,7 @@ else:
 amount_difference = next_states[0].amount - leader_state.amount
 require(amount_difference > amount_threshold)
 require(next_states[0].borrow_scheme == leader_state.borrow_scheme)
-require(next_states[0].borrow_guard == next_borrow_guard)
 ```
-
-`Hash` is the KCC1 Hash Function. Every borrow signature used by
-`schnorr-signature/v1` or `hash-chain/v1` must be a `SIGHASH_ALL` Schnorr
-transaction signature that commits to the complete borrowed-receive
-transaction.
 
 Every borrowed receive must increase the borrowed state's token amount. For
 the `schnorr-signature/v1` and `hash-chain/v1` schemes, any positive increase is

--- a/kcc-0020/borrowed-receive-authorization.md
+++ b/kcc-0020/borrowed-receive-authorization.md
@@ -45,10 +45,6 @@ Some schemes require a scheme-specific `borrow_witness`.
 Every borrowed receive preserves `borrow_scheme`. A normal owner-authorized
 transfer may replace both `borrow_scheme` and `borrow_guard`.
 
-Every signature used by `schnorr-signature/v1` or `hash-chain/v1` is a
-`SIGHASH_ALL` Schnorr transaction signature that commits to the complete
-borrowed-receive transaction.
-
 ### `disabled/v1`
 
 The `disabled/v1` scheme rejects borrowed receives.
@@ -71,8 +67,7 @@ KAS value.
 
 The `hash-chain/v1` scheme allows one borrow per released chain link. Each link
 is a one-time authorization bound to its own signing key and advances
-`borrow_guard` when used. A wallet can prepare a finite chain and release links
-only when it expects the UTXO to change.
+`borrow_guard` when used. A wallet can prepare a finite chain and release links at will to authorize individual borrows.
 
 The idea originates in Rivest and Shamir's [PayWord and MicroMint: Two Simple
 Micropayment Schemes](https://people.csail.mit.edu/rivest/pubs/RS96a.pdf). KCC20
@@ -100,32 +95,22 @@ VerifySchnorr(pubkey_i, transaction, signature_i)
 ```
 
 The wallet gives the intended sender `x_(i-1)` and `private_key_i`. The revealed
-value becomes the successor's `borrow_guard`, ready for the next borrow.
+value `x_(i-1)` becomes the successor's `borrow_guard`, ready for the next borrow.
 
 The authorizations are revealed in reverse order and cannot be reused. The
 wallet may release them one at a time while monitoring each borrow, or several
 in advance while accepting that its outpoint may change until they are consumed
 or revoked. The chain is exhausted after `x_0` is revealed.
 
-The authorization is normally shared with an intended sender and is bound to
-its one-time signing key. Once a transaction reveals the preimage, public key,
-and signature in the mempool, another party may rebroadcast that transaction
-but cannot use the authorization in a different transaction without the private
-key.
+#### Wallet-control model
 
-#### Wallet synchronization
+The hash-chain scheme is designed to keep the recipient's wallet in control of
+when its UTXO may change. The wallet releases one authorization while monitoring
+the network, records the confirmed successor outpoint, and keeps the next
+authorization private until another change is expected. Without a released
+authorization, the UTXO cannot be borrowed, so the wallet may go offline knowing
+that its outpoint will remain stable.
 
-Ordinary receives create new UTXOs and leave a wallet's existing UTXOs
-unchanged. Borrowed Receive can instead recreate an existing UTXO without owner
-authorization, so the wallet may need to synchronize to learn its new outpoint.
-
-`disabled/v1` prevents such changes. `amount-threshold/v1` allows any sender
-above the threshold to cause them, while `schnorr-signature/v1` gives an
-approved borrower reusable permission. `hash-chain/v1` is the only enabled
-scheme in which the wallet grants each borrow separately.
-
-The wallet can release one authorization, wait for the borrow, and record its
-successor. If no borrow appears, it can revoke the authorization by advancing
-the guard. Once the guard update confirms, the released authorization is
-invalid. Without another released authorization, the outpoint cannot change
-through Borrowed Receive.
+Before going offline, a wallet that has released an authorization which remains
+unused may revoke it through an owner-authorized transfer or consume it itself
+in a valid borrowed receive.

--- a/kcc-0020/borrowed-receive-authorization.md
+++ b/kcc-0020/borrowed-receive-authorization.md
@@ -59,9 +59,8 @@ increase. No `borrow_witness` is required.
 ### `schnorr-signature/v1`
 
 The `schnorr-signature/v1` scheme allows the holder of a dedicated borrow key to
-authorize repeated borrows. Each borrow requires a signature for the complete
-transaction. The key cannot spend the recipient's tokens or reduce the UTXO's
-KAS value.
+authorize repeated borrows. Each borrow requires a valid transaction signature.
+The key cannot spend the recipient's tokens or reduce the UTXO's KAS value.
 
 ### `hash-chain/v1`
 

--- a/kcc-0020/borrowed-receive-authorization.md
+++ b/kcc-0020/borrowed-receive-authorization.md
@@ -18,16 +18,14 @@ consumes the existing UTXO and recreates it in place with a larger token amount.
 The recipient's normal owner authorization is not used, the KAS value cannot
 decrease, and the owner and extended state remain unchanged.
 
-Because the existing UTXO is consumed, every borrowed receive changes its
-outpoint. Without restrictions, an attacker could repeatedly send tiny token
-amounts to churn that outpoint. A wallet, signing device, or service relying on
-its locally known UTXOs would then have to reconnect and rediscover the current
-UTXO before using it.
+Because a borrowed receive consumes and recreates an existing UTXO, it changes
+that UTXO's outpoint. A wallet that did not expect the borrow may need to
+synchronize and discover the successor before using its recorded UTXO.
 
-The borrow scheme controls who may cause this limited state change, or under
-what conditions it is allowed. It cannot remove the need to learn the new
-outpoint after an actual borrow, but it can prevent arbitrary or low-value
-borrows from making locally stored UTXO information stale.
+Unrestricted borrowing also enables outpoint-churn spam. An attacker can
+repeatedly recreate the UTXO through token-dust transfers, continually changing
+its outpoint and invalidating transactions constructed to spend the previous
+one.
 
 ## Borrow authorization
 
@@ -35,16 +33,14 @@ Each KCC20 state contains a `borrow_scheme` and a 32-byte `borrow_guard`.
 `borrow_scheme` selects the authorization rule, while `borrow_guard` holds its
 parameter or evolving state.
 
-Some schemes require an authorization parameter when borrowing. This parameter
-is referred to as `borrow_witness` and its meaning depends on the selected
-scheme.
+Some schemes require a scheme-specific `borrow_witness`.
 
-| Scheme | Meaning of `borrow_guard` | `borrow_witness` | Successor `borrow_guard` |
+| Scheme | Control model | `borrow_guard` | `borrow_witness` |
 | --- | --- | --- | --- |
-| `disabled/v1` | Unused | Borrowing is rejected | Not applicable |
-| `amount-threshold/v1` | First eight bytes contain the threshold | Empty | Unchanged |
-| `schnorr-signature/v1` | Dedicated 32-byte public key | 65-byte Schnorr transaction signature | Unchanged |
-| `hash-chain/v1` | Current 32-byte hash-chain commitment | 32-byte preimage, 32-byte one-time Schnorr public key, and 65-byte Schnorr transaction signature | Revealed preimage |
+| `disabled/v1` | No borrowing | Unused | Borrowing is rejected |
+| `amount-threshold/v1` | Any sender above threshold | Threshold in first eight bytes | Empty |
+| `schnorr-signature/v1` | Approved borrower, reusable | Dedicated 32-byte public key | 65-byte Schnorr transaction signature |
+| `hash-chain/v1` | Approved borrow, single-use | Current 32-byte hash-chain commitment | 32-byte preimage, 32-byte one-time public key, and 65-byte signature |
 
 Every borrowed receive preserves `borrow_scheme`. A normal owner-authorized
 transfer may replace both `borrow_scheme` and `borrow_guard`.
@@ -53,43 +49,30 @@ Every signature used by `schnorr-signature/v1` or `hash-chain/v1` is a
 `SIGHASH_ALL` Schnorr transaction signature that commits to the complete
 borrowed-receive transaction.
 
-Together, these schemes cover disabled borrowing, permissionless borrowing for
-any positive increase, permissionless borrowing above a configured threshold,
-repeated authorization by a borrow key, and single-use authorization by a
-key-bound hash-chain OTP.
-
 ### `disabled/v1`
 
-The `disabled/v1` scheme prevents the UTXO from being borrowed and does not use
-`borrow_guard`. Receiving tokens therefore requires a separate output.
+The `disabled/v1` scheme rejects borrowed receives.
 
 ### `amount-threshold/v1`
 
-The `amount-threshold/v1` scheme permits borrowing without sender-specific
-authorization. The first eight bytes of `borrow_guard` contain the threshold
-that the token increase must strictly exceed; the remaining bytes are unused.
-A zero threshold allows anyone to borrow by adding any positive token amount. A
-positive threshold makes dust-level token spam ineffective, although
-sufficiently large transfers can still change the outpoint. No borrow witness
-is required.
+The `amount-threshold/v1` scheme allows any sender to borrow when the token
+increase exceeds the threshold stored in `borrow_guard`. A positive threshold
+mitigates dust-based outpoint churn; a zero threshold allows any positive
+increase. No `borrow_witness` is required.
 
 ### `schnorr-signature/v1`
 
-The `schnorr-signature/v1` scheme stores a dedicated borrow public key in
-`borrow_guard`. A sender with access to the corresponding borrow signing key may
-authorize repeated borrows. This supports controlled reuse by recurring trusted
-senders without granting permission to spend the recipient's tokens or reduce
-the UTXO's KAS value. Other senders cannot make the locally recorded outpoint
-stale through Borrowed Receive. The owner can rotate the borrow key or select a
-different scheme through a normal owner-authorized transfer.
+The `schnorr-signature/v1` scheme allows the holder of a dedicated borrow key to
+authorize repeated borrows. Each borrow requires a signature for the complete
+transaction. The key cannot spend the recipient's tokens or reduce the UTXO's
+KAS value.
 
 ### `hash-chain/v1`
 
-The `hash-chain/v1` scheme uses `borrow_guard` as the current commitment to an
-OTP-like sequence of one-time borrow authorizations. A wallet can preallocate a
-finite number of authorizations in advance. Each borrowed receive consumes one
-authorization and advances `borrow_guard`, without requiring a new signature
-from the recipient.
+The `hash-chain/v1` scheme allows one borrow per released chain link. Each link
+is a one-time authorization bound to its own signing key and advances
+`borrow_guard` when used. A wallet can prepare a finite chain and release links
+only when it expects the UTXO to change.
 
 The idea originates in Rivest and Shamir's [PayWord and MicroMint: Two Simple
 Micropayment Schemes](https://people.csail.mit.edu/rivest/pubs/RS96a.pdf). KCC20
@@ -124,21 +107,25 @@ wallet may release them one at a time while monitoring each borrow, or several
 in advance while accepting that its outpoint may change until they are consumed
 or revoked. The chain is exhausted after `x_0` is revealed.
 
-#### Wallet-control model
-
-The hash-chain scheme is designed to keep the recipient's wallet in control of
-when its UTXO may change. The wallet releases one authorization while monitoring
-the network, records the confirmed successor outpoint, and keeps the next
-authorization private until another change is expected. Without a released
-authorization, the UTXO cannot be borrowed, so the wallet may go offline knowing
-that its outpoint will remain stable.
-
 The authorization is normally shared with an intended sender and is bound to
 its one-time signing key. Once a transaction reveals the preimage, public key,
 and signature in the mempool, another party may rebroadcast that transaction
 but cannot use the authorization in a different transaction without the private
 key.
 
-Before going offline, a wallet that has released an authorization which remains
-unused may revoke it through an owner-authorized transfer or consume it itself
-in a valid borrowed receive.
+#### Wallet synchronization
+
+Ordinary receives create new UTXOs and leave a wallet's existing UTXOs
+unchanged. Borrowed Receive can instead recreate an existing UTXO without owner
+authorization, so the wallet may need to synchronize to learn its new outpoint.
+
+`disabled/v1` prevents such changes. `amount-threshold/v1` allows any sender
+above the threshold to cause them, while `schnorr-signature/v1` gives an
+approved borrower reusable permission. `hash-chain/v1` is the only enabled
+scheme in which the wallet grants each borrow separately.
+
+The wallet can release one authorization, wait for the borrow, and record its
+successor. If no borrow appears, it can revoke the authorization by advancing
+the guard. Once the guard update confirms, the released authorization is
+invalid. Without another released authorization, the outpoint cannot change
+through Borrowed Receive.

--- a/kcc-0020/borrowed-receive-authorization.md
+++ b/kcc-0020/borrowed-receive-authorization.md
@@ -44,10 +44,19 @@ scheme.
 | `disabled/v1` | Unused | Borrowing is rejected | Not applicable |
 | `amount-threshold/v1` | First eight bytes contain the threshold | Empty | Unchanged |
 | `schnorr-signature/v1` | Dedicated 32-byte public key | 65-byte Schnorr transaction signature | Unchanged |
-| `hash-chain/v1` | Current 32-byte hash | Its 32-byte preimage | Revealed preimage |
+| `hash-chain/v1` | Current 32-byte hash-chain commitment | 32-byte preimage, 32-byte one-time Schnorr public key, and 65-byte Schnorr transaction signature | Revealed preimage |
 
 Every borrowed receive preserves `borrow_scheme`. A normal owner-authorized
 transfer may replace both `borrow_scheme` and `borrow_guard`.
+
+Every signature used by `schnorr-signature/v1` or `hash-chain/v1` is a
+`SIGHASH_ALL` Schnorr transaction signature that commits to the complete
+borrowed-receive transaction.
+
+Together, these schemes cover disabled borrowing, permissionless borrowing for
+any positive increase, permissionless borrowing above a configured threshold,
+repeated authorization by a borrow key, and single-use authorization by a
+key-bound hash-chain OTP.
 
 ### `disabled/v1`
 
@@ -59,8 +68,10 @@ The `disabled/v1` scheme prevents the UTXO from being borrowed and does not use
 The `amount-threshold/v1` scheme permits borrowing without sender-specific
 authorization. The first eight bytes of `borrow_guard` contain the threshold
 that the token increase must strictly exceed; the remaining bytes are unused.
-This makes dust-level token spam ineffective, although sufficiently large
-transfers can still change the outpoint. No borrow witness is required.
+A zero threshold allows anyone to borrow by adding any positive token amount. A
+positive threshold makes dust-level token spam ineffective, although
+sufficiently large transfers can still change the outpoint. No borrow witness
+is required.
 
 ### `schnorr-signature/v1`
 
@@ -69,7 +80,8 @@ The `schnorr-signature/v1` scheme stores a dedicated borrow public key in
 authorize repeated borrows. This supports controlled reuse by recurring trusted
 senders without granting permission to spend the recipient's tokens or reduce
 the UTXO's KAS value. Other senders cannot make the locally recorded outpoint
-stale through Borrowed Receive.
+stale through Borrowed Receive. The owner can rotate the borrow key or select a
+different scheme through a normal owner-authorized transfer.
 
 ### `hash-chain/v1`
 
@@ -80,22 +92,32 @@ authorization and advances `borrow_guard`, without requiring a new signature
 from the recipient.
 
 The idea originates in Rivest and Shamir's [PayWord and MicroMint: Two Simple
-Micropayment Schemes](https://people.csail.mit.edu/rivest/pubs/RS96a.pdf).
+Micropayment Schemes](https://people.csail.mit.edu/rivest/pubs/RS96a.pdf). KCC20
+adapts the one-way hash-chain construction by binding each link to a distinct
+one-time Schnorr key.
 
 To prepare a chain for `n` borrows, the wallet chooses a random value `x_0` and
-computes:
+`n` one-time Schnorr keypairs `(private_key_i, pubkey_i)`, then computes:
 
 ```text
-x_1 = Hash(x_0)
-x_2 = Hash(x_1)
+x_1 = Hash(x_0 || pubkey_1)
+x_2 = Hash(x_1 || pubkey_2)
 ...
-x_n = Hash(x_(n-1))
+x_n = Hash(x_(n-1) || pubkey_n)
 ```
 
 The initial `borrow_guard` is `x_n`, which commits to the complete sequence. A
-borrow against guard `x_i` reveals `x_(i-1)` and proves the authorization by
-requiring `Hash(x_(i-1)) == x_i`. The revealed value becomes the successor's
-`borrow_guard`, ready for the next borrow.
+borrow against guard `x_i` reveals `x_(i-1)` and `pubkey_i`, and includes a
+transaction signature by the corresponding one-time private key. It proves the
+authorization by requiring:
+
+```text
+Hash(x_(i-1) || pubkey_i) == x_i
+VerifySchnorr(pubkey_i, transaction, signature_i)
+```
+
+The wallet gives the intended sender `x_(i-1)` and `private_key_i`. The revealed
+value becomes the successor's `borrow_guard`, ready for the next borrow.
 
 The authorizations are revealed in reverse order and cannot be reused. The
 wallet may release them one at a time while monitoring each borrow, or several
@@ -111,15 +133,12 @@ authorization private until another change is expected. Without a released
 authorization, the UTXO cannot be borrowed, so the wallet may go offline knowing
 that its outpoint will remain stable.
 
-The authorization is normally shared with an intended sender, but is not
-strictly bound to that sender. Once a transaction reveals it in the mempool,
-another party may copy it into a different valid borrowed-receive transaction
-and attempt to have that transaction confirmed first. Because both transactions
-spend the same UTXO, only one can be accepted. The competing transaction must
-still increase the recipient's token amount and preserve its KAS value, limiting
-the incentive for this form of front-running.
+The authorization is normally shared with an intended sender and is bound to
+its one-time signing key. Once a transaction reveals the preimage, public key,
+and signature in the mempool, another party may rebroadcast that transaction
+but cannot use the authorization in a different transaction without the private
+key.
 
 Before going offline, a wallet that has released an authorization which remains
 unused may revoke it through an owner-authorized transfer or consume it itself
-in a valid borrowed receive. Applications that instead require
-transaction-specific authorization may use the Schnorr-signature scheme.
+in a valid borrowed receive.


### PR DESCRIPTION
Binds each hash-chain borrow authorization to a one-time Schnorr key to prevent mempool front-running.