### PR TITLE
feat(kcc-01/dipatch-tag): hardening include record fields

### DIFF
--- a/kcc-0001.md
+++ b/kcc-0001.md
@@ -367,14 +367,27 @@ Covenant programs MUST contain at least one entrypoint.
 
 ### 6.1 Dispatch tag
 
+For dispatch-tag construction, `DispatchTypeName(T)` is defined recursively:
+
+| Type                                            | Dispatch type name                                  |
+| ----------------------------------------------- | --------------------------------------------------- |
+| Scalar                                          | `TypeName(T)`                                       |
+| Fixed array of `T` with length `N`              | `DispatchTypeName(T)[N]`                            |
+| Dynamic array of `T`                            | `DispatchTypeName(T)[]`                             |
+| Record with ordered field types `T_1, ..., T_n` | `{DispatchTypeName(T_1),...,DispatchTypeName(T_n)}` |
+
+A record's dispatch type name contains only its ordered field types. Record
+names and field names are omitted. The braces, brackets, and commas shown above
+are literal, and no whitespace is inserted.
+
 For an entrypoint named `name`, define:
 
 ```text
-FunctionSignature = UTF8("{name}({comma-separated canonical type names})")
+FunctionSignature = UTF8("{name}({comma-separated dispatch type names})")
 dispatch_tag      = Hash(FunctionSignature)[0:4]
 ```
 
-The type names are enclosed in parentheses and separated by commas. No
+The dispatch type names are enclosed in parentheses and separated by commas. No
 whitespace, length field, or terminator is inserted into `FunctionSignature`.
 For an entrypoint with no arguments, the sequence of type names and commas is
 empty, so the signature ends with `UTF8("()")`.
@@ -749,6 +762,21 @@ byte 01           = 51
 dispatch-tag push = 042c49ed65
 
 combined          = 011104010203045151042c49ed65
+```
+
+For an entrypoint with a dynamic array of records:
+
+```text
+name                       = "dispense"
+types                      = (CoffeeOrder[])
+CoffeeOrder ordered fields = (byte[4] recipe_code, byte sugar_level, bool with_milk)
+```
+
+the signature and dispatch tag are:
+
+```text
+FunctionSignature = UTF8("dispense({byte[4],byte,bool}[])")
+dispatch_tag      = 676b1a86
 ```
 
 ### 11.2 P2SH envelope


### PR DESCRIPTION
ctx: https://t.me/kasparnd/12273/15691

goal is to encode record fields within the dipatch tag: `UTF8("transfer({int, byte[4]}[], int)")`, not only the record name (that isn't always defined).