### PR TITLE
KCC-2: add p2pk-ecdsa schemes (0x05/0x06)

### DIFF
--- a/kcc-0002.md
+++ b/kcc-0002.md
@@ -29,13 +29,15 @@ scheme** defines the value's KCC1 type, meaning, and minimum approval check.
 The following byte identifiers are canonical wherever a Program ABI or a
 higher-level convention selects a KCC2 authority scheme:
 
-| Byte   | Scheme             | Compatible KCC1 value                                 | Authority                             |
-| ------ | ------------------ | ----------------------------------------------------- | ------------------------------------- |
-| `0x00` | `p2pk-schnorr/v1`  | `pubkey`                                              | The 32-byte Schnorr public key itself |
-| `0x01` | `p2pkh-schnorr/v1` | `byte[32]` containing `P2PKHHash(pubkey)`             | A 32-byte Schnorr public key          |
-| `0x02` | `p2pkh-ecdsa/v1`   | `byte[32]` containing `P2PKHHash(ecdsa_pubkey)`       | A compressed 33-byte ECDSA public key |
-| `0x03` | `p2sh/v1`          | `byte[32]` containing the KCC1 P2SH commitment to `R` | One exact P2SH redeem script          |
-| `0x04` | `covenant-id/v1`   | `byte[32]` containing a KIP-20 Covenant ID            | One continuing covenant lineage       |
+| Byte   | Scheme               | Compatible KCC1 value                                    | Authority                                                            |
+| ------ | -------------------- | -------------------------------------------------------- | -------------------------------------------------------------------- |
+| `0x00` | `p2pk-schnorr/v1`    | `pubkey`                                                 | The 32-byte Schnorr public key itself                                |
+| `0x01` | `p2pkh-schnorr/v1`   | `byte[32]` containing `P2PKHHash(pubkey)`                | A 32-byte Schnorr public key                                         |
+| `0x02` | `p2pkh-ecdsa/v1`     | `byte[32]` containing `P2PKHHash(ecdsa_pubkey)`          | A compressed 33-byte ECDSA public key                                |
+| `0x03` | `p2sh/v1`            | `byte[32]` containing the KCC1 P2SH commitment to `R`    | One exact P2SH redeem script                                         |
+| `0x04` | `covenant-id/v1`     | `byte[32]` containing a KIP-20 Covenant ID               | One continuing covenant lineage                                      |
+| `0x05` | `p2pk-ecdsa-odd/v1`  | `byte[32]` containing the x coordinate of `ecdsa_pubkey` | A compressed 33-byte ECDSA public key with odd y (SEC1 prefix `03`)  |
+| `0x06` | `p2pk-ecdsa-even/v1` | `byte[32]` containing the x coordinate of `ecdsa_pubkey` | A compressed 33-byte ECDSA public key with even y (SEC1 prefix `02`) |
 
 The byte identifies the scheme, not the authority. A higher-level convention
 MAY support only a subset of these schemes, but MUST use the canonical byte for
@@ -63,6 +65,23 @@ key stored in the authority value.
 Approval under either P2PKH scheme MUST reveal the corresponding public key,
 require its `P2PKHHash` to equal the authority value, and include a valid
 signature by that key.
+
+The P2PK ECDSA schemes hold a compressed 33-byte ECDSA public key across the
+scheme byte and the authority value. The authority value is the 32-byte x
+coordinate, and the lowest bit of the scheme byte is the y parity of the key:
+`1` for `p2pk-ecdsa-odd/v1` (`0x05`) and `0` for `p2pk-ecdsa-even/v1` (`0x06`).
+The public key is therefore:
+
+```text
+prefix       = 03 for p2pk-ecdsa-odd/v1, 02 for p2pk-ecdsa-even/v1
+ecdsa_pubkey = prefix || authority_value
+```
+
+Approval under either P2PK ECDSA scheme MUST include a valid ECDSA signature by
+`ecdsa_pubkey`. The same x coordinate under the two schemes names two different
+public keys and therefore two different authorities. The scheme byte is
+determined by the public key, and a Kaspa `PubKeyECDSA` address carries
+`ecdsa_pubkey` as its payload, so both fields are derivable from the address.
 
 The higher-level convention defines the signed message, signature encoding,
 witness location, and any additional authorization conditions.

--- a/kcc-0002/reference-code.md
+++ b/kcc-0002/reference-code.md
@@ -87,6 +87,25 @@ function requireCovenantId(byte[32] authority) {
 }
 ```
 
+## 6. Silverscript P2PK ECDSA
+
+The following code verifies `p2pk-ecdsa-odd/v1` and `p2pk-ecdsa-even/v1`:
+
+```js
+byte constant SEC1_EVEN = 0x02;
+byte constant PARITY_MASK = 0x01;
+
+function requireP2PKECDSA(
+    byte scheme,        // 0x05 (p2pk-ecdsa-odd/v1) or 0x06 (p2pk-ecdsa-even/v1)
+    byte[32] authority, // the x coordinate of the public key
+    sig signature
+) {
+    byte prefix = SEC1_EVEN | (scheme & PARITY_MASK);
+    byte[33] publicKey = byte[33](byte[](prefix) + byte[](authority));
+    require(checkSigEcdsa(signature, publicKey));
+}
+```
+
 ### Argent reference code
 
 Argent is a language and transpiler for multi-contract, multi-application


### PR DESCRIPTION
Add p2pk-ecdsa authority schemes to KCC-2

KCC-2 has a P2PK scheme for Schnorr (0x00) but only a P2PKH scheme for ECDSA (0x02). This adds the missing P2PK form for ECDSA as two scheme bytes, 0x05 and 0x06, one per y parity.

Why the form is needed: a P2PKH authority is a hash. The key only appears on chain when the authority is spent, so nothing can render the current holder of a P2PKH authority back to an address while it is held. Conventions that need to display or index the current holder have no way to hold an ECDSA owner today. P2PK Schnorr has this property; ECDSA has no equivalent.

Why two bytes: a compressed ECDSA key is 33 bytes and the authority value is 32. The x coordinate goes in the value and the SEC1 prefix parity goes in the low bit of the scheme byte, so the covenant rebuilds the key as (0x02 | (scheme & 1)) || value without a branch and without revealing anything in the witness. Every authority value stays 32 bytes, which keeps KCC-1 state layouts unchanged.

Why it fits Kaspa: the node, mempool and reference wallet all implement P2PK ECDSA natively (address version PubKeyECDSA, the standard OP_DATA_33 <key> OP_CHECKSIGECDSA output, and ECDSA accounts in the wallet). The proposed schemes round-trip to a PubKeyECDSA address with no extra data, the same way p2pk-schnorr/v1 round-trips to a PubKey address.